### PR TITLE
Add tasks and abstraction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 *.o
 *.a
 mkmf.log
+.env

--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,4 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'coveralls', require: false
+gem 'dotenv'

--- a/Gemfile
+++ b/Gemfile
@@ -4,4 +4,3 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'coveralls', require: false
-gem 'dotenv'

--- a/README.md
+++ b/README.md
@@ -77,13 +77,6 @@ $ rake geocombine:index["http://solr_url.edu/solr"]
 
 Indexes all of the `geoblacklight.xml` files in cloned repositories to a Solr index running at given URI, or at http://127.0.0.1:8983/solr by default
 
-### Clear the index (solr URI is optional)
-
-```sh
-$ rake geocombine:delete["http://solr_url.edu/solr"]
-```
-
-Deletes everything from the given solr index, or http://127.0.0.1:8983/solr by default
 
 ### Clone and index in one command (useful for first runs) (solr URI is optional)
 

--- a/README.md
+++ b/README.md
@@ -57,13 +57,37 @@ $ rake geocombine:pull
 
 Runs `git pull origin master` on all cloned repositories in `./tmp`
 
-### Index all of the GeoBlacklight documents
+### Delete files from cloning repositories
 
 ```sh
-$ rake geocombine:index
+$ rake geocombine:clean
 ```
 
-Indexs all of the `geoblacklight.xml` files in cloned repositories to a Solr index running at http://127.0.0.1:8983/solr
+Will recursively delete the `./tmp` directory
+
+### Index all of the GeoBlacklight documents (solr URI is optional)
+
+```sh
+$ rake geocombine:index["http://solr_url.edu/solr"]
+```
+
+Indexes all of the `geoblacklight.xml` files in cloned repositories to a Solr index running at given URI, or at http://127.0.0.1:8983/solr by default
+
+### Clear the index (solr URI is optional)
+
+```sh
+$ rake geocombine:delete["http://solr_url.edu/solr"]
+```
+
+Deletes everything from the given solr index, or http://127.0.0.1:8983/solr by default
+
+### Clone and index in one command (useful for first runs) (solr URI is optional)
+
+```sh
+$ rake geocombine:all["http://solr_url.edu/solr"]
+```
+
+The same as running geocombine:clone and gecombine:index (at given URI, or http://127.0.0.1:8983/solr by default)
 
 ## Contributing
 

--- a/lib/tasks/geo_combine.rake
+++ b/lib/tasks/geo_combine.rake
@@ -2,10 +2,16 @@ require 'find'
 require 'net/http'
 require 'json'
 require 'rsolr'
+require 'fileutils'
+require 'dotenv/tasks'
 
 namespace :geocombine do
+  desc 'Clone and index all in one go'
+  task :all, [:solr_url] => [:clone, :index]
+
   desc 'Clone all OpenGeoMetadata repositories'
   task :clone do
+    FileUtils.mkdir_p('tmp')
     ogm_api_uri = URI('https://api.github.com/orgs/opengeometadata/repos')
     ogm_repos = JSON.parse(Net::HTTP.get(ogm_api_uri)).map{ |repo| repo['git_url']}
     ogm_repos.each do |repo|
@@ -14,23 +20,69 @@ namespace :geocombine do
       end
     end
   end
+
+  desc 'Delete the tmp directory'
+  task :clean do
+    puts "Removing 'tmp' directory." if verbose == true
+    FileUtils.rm_rf('tmp') 
+  end
+
+  desc "Delete the Solr index"
+  task :delete , [:solr_url]  => :dotenv do |t, args|
+    begin
+      args.with_defaults(solr_url: ENV.fetch('solr_url', 'http://127.0.0.1:8983/solr'))
+      solr = RSolr.connect :url => args[:solr_url]
+      puts "Deleting the Solr index." if verbose == true
+      solr.delete_by_query '*:*'
+      solr.optimize
+    rescue Exception => e
+      puts "\nError: #{e}" if verbose == true
+    end
+  end
+
   desc '"git pull" OpenGeoMetadata repositories'
   task :pull do
     Dir.glob('tmp/*').map{ |dir| system "cd #{dir} && git pull origin master" if dir =~ /.*edu.*./ }
   end
+
   desc 'Index all of the GeoBlacklight documents'
-  task :index do
-    solr = RSolr.connect :url => 'http://127.0.0.1:8983/solr'
-    Find.find('tmp') do |path|
-      if path =~ /.*geoblacklight.xml$/
-        doc = File.read(path)
+  task :index, [:solr_url] => :dotenv do |t, args|
+    begin
+      args.with_defaults(solr_url: ENV.fetch('solr_url', 'http://127.0.0.1:8983/solr'))
+      solr = RSolr.connect :url => args[:solr_url], :read_timeout => 720
+
+      puts "Finding geoblacklight.xml files." if verbose == true
+      xml_files = Dir.glob("tmp/**/*geoblacklight.xml")
+
+      puts "Loading files into solr." if verbose == true
+      xml_files.each_with_index do |file, i|
+        @the_file = file
+        doc = File.read(file)
         begin
           solr.update data: doc
-          solr.commit
         rescue RSolr::Error::Http => error
-          puts error
+          puts "\n#{file}\n#{error}" if verbose == true
+          next
+        end
+
+        if verbose == true
+          if i % 100 == 0 && i > 0
+            print "." 
+            if i % 1000 == 0
+              puts " #{i} files uploaded."
+            end
+          end
         end
       end
+
+    rescue Exception => e
+      puts "\n#{@the_file}\nError: #{e}" if verbose == true
+      next
     end
+
+    puts "\nIndexing and optimizing Solr." if verbose == true
+    solr.commit
+    solr.optimize
+    puts "\n" if verbose == true
   end
 end

--- a/lib/tasks/geo_combine.rake
+++ b/lib/tasks/geo_combine.rake
@@ -3,13 +3,14 @@ require 'net/http'
 require 'json'
 require 'rsolr'
 require 'fileutils'
-require 'dotenv/tasks'
+
+ogm_path = ENV['OGM_PATH'] || 'tmp/opengeometadata'
+solr_url = ENV['SOLR_URL'] || 'http://127.0.0.1:8983/solr'
 
 namespace :geocombine do
   desc 'Clone and index all in one go'
-  task :all, [:solr_url] => [:clone, :index]
+  task :all => [:clone, :index]
 
-  ogm_path = ENV['OGM_PATH'] || 'tmp/opengeometadata'
   desc 'Clone all OpenGeoMetadata repositories'
   task :clone do
     FileUtils.mkdir_p(ogm_path)
@@ -28,29 +29,15 @@ namespace :geocombine do
     FileUtils.rm_rf(ogm_path) 
   end
 
-  desc "Delete the Solr index"
-  task :delete , [:solr_url]  => :dotenv do |t, args|
-    begin
-      args.with_defaults(solr_url: ENV.fetch('solr_url', 'http://127.0.0.1:8983/solr'))
-      solr = RSolr.connect :url => args[:solr_url]
-      puts "Deleting the Solr index." if verbose == true
-      solr.delete_by_query '*:*'
-      solr.optimize
-    rescue Exception => e
-      puts "\nError: #{e}" if verbose == true
-    end
-  end
-
   desc '"git pull" OpenGeoMetadata repositories'
   task :pull do
     Dir.glob("#{ogm_path}/*").map{ |dir| system "cd #{dir} && git pull origin master" if dir =~ /.*edu.*./ }
   end
 
   desc 'Index all of the GeoBlacklight documents'
-  task :index, [:solr_url] => :dotenv do |t, args|
+  task :index  do
     begin
-      args.with_defaults(solr_url: ENV.fetch('solr_url', 'http://127.0.0.1:8983/solr'))
-      solr = RSolr.connect :url => args[:solr_url], :read_timeout => 720
+      solr = RSolr.connect :url => solr_url, :read_timeout => 720
 
       puts "Finding geoblacklight.xml files." if verbose == true
       xml_files = Dir.glob("#{ogm_path}/**/*geoblacklight.xml")


### PR DESCRIPTION
This request adds three new rake tasks: 
- clean: to delete the tmp directory
- delete: to delete the Solr index
- all: combines clone and index for easier first time use

Also, abstracts the Solr URL for better handling of alternative Solr installations. Use of an .env file is supported, as well as adding the URL to the rake tasks (index, delete, and all).

Additionally, the --verbose flag can be used to see output.
