### PR TITLE
adds in basic geoblacklight schema validation and geoblacklight enhancment metadata

### DIFF
--- a/geo_combine.gemspec
+++ b/geo_combine.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'rsolr'
   spec.add_dependency 'nokogiri'
+  spec.add_dependency 'json-schema'
 
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/lib/geo_combine.rb
+++ b/lib/geo_combine.rb
@@ -30,7 +30,10 @@ module GeoCombine
 
     ##
     # Perform an XSLT tranformation on metadata using an object's XSL
-    # @return [GeoCombine::Geoblacklight] the data transformed into geoblacklight schema, returned as a GeoCombine::Geoblacklight
+    # @return fields additional GeoBlacklight fields to be passed to
+    # GeoCombine::Geoblacklight on its instantiation
+    # @return [GeoCombine::Geoblacklight] the data transformed into
+    # geoblacklight schema, returned as a GeoCombine::Geoblacklight
     def to_geoblacklight fields = {}
       GeoCombine::Geoblacklight.new(xsl_geoblacklight.apply_to(@metadata), fields)
     end
@@ -43,6 +46,9 @@ module GeoCombine
     end
   end
 end
+
+require 'geo_combine/formats'
+require 'geo_combine/subjects'
 
 require 'geo_combine/fgdc'
 require 'geo_combine/geoblacklight'

--- a/lib/geo_combine.rb
+++ b/lib/geo_combine.rb
@@ -1,4 +1,6 @@
 require 'nokogiri'
+require 'json'
+require 'json-schema'
 
 module GeoCombine
 

--- a/lib/geo_combine.rb
+++ b/lib/geo_combine.rb
@@ -31,8 +31,8 @@ module GeoCombine
     ##
     # Perform an XSLT tranformation on metadata using an object's XSL
     # @return [GeoCombine::Geoblacklight] the data transformed into geoblacklight schema, returned as a GeoCombine::Geoblacklight
-    def to_geoblacklight
-      GeoCombine::Geoblacklight.new(xsl_geoblacklight.transform(@metadata))
+    def to_geoblacklight fields = {}
+      GeoCombine::Geoblacklight.new(xsl_geoblacklight.apply_to(@metadata), fields)
     end
 
     ##

--- a/lib/geo_combine/formats.rb
+++ b/lib/geo_combine/formats.rb
@@ -1,0 +1,11 @@
+module GeoCombine
+  ##
+  # Translation dictionary for mime-type to valid GeoBlacklight-Schema formats
+  module Formats
+    def formats
+      {
+        'application/x-esri-shapefile' => 'Shapefile'
+      }
+    end
+  end
+end

--- a/lib/geo_combine/geoblacklight.rb
+++ b/lib/geo_combine/geoblacklight.rb
@@ -9,6 +9,14 @@ module GeoCombine
     end
 
     ##
+    # Validates a GeoBlacklight-Schema json document
+    # @return [Boolean]
+    def valid?
+      schema = JSON.parse(File.read(File.join(File.dirname(__FILE__), '../schema/geoblacklight-schema.json')))
+      JSON::Validator.validate!(schema, JSON.parse(to_json), validate_schema: true)
+    end
+
+    ##
     # Returns a hash from a GeoBlacklight object
     # @return (Hash)
     def to_hash
@@ -17,7 +25,7 @@ module GeoCombine
         (hash[field.attributes['name'].value] ||= []) << field.children.text
       end
       hash.collect do |key, value|
-        hash[key] = value.count > 1 ? { key => value } : { key => value[0] }
+        hash[key] = value.count > 1 ? value : value[0]
       end
       hash
     end

--- a/lib/geo_combine/subjects.rb
+++ b/lib/geo_combine/subjects.rb
@@ -1,0 +1,29 @@
+module GeoCombine
+  ##
+  # Translation dictionary to ISO topics
+  module Subjects
+    def subjects
+      {
+        'farming' => 'Farming',
+        'biota' => 'Biology and Ecology',
+        'climatologyMeteorologyAtmosphere' => 'Climatology, Meteorology and Atmosphere',
+        'boundaries' => 'Boundaries',
+        'elevation' => 'Elevation',
+        'environment' => 'Environment',
+        'geoscientificInformation' => 'Geoscientific Information',
+        'health' => 'Health',
+        'imageryBaseMapsEarthCover' => 'Imagery and Base Maps',
+        'intelligenceMilitary' => 'Military',
+        'inlandWaters' => 'Inland Waters',
+        'location' => 'Location',
+        'oceans' => 'Oceans',
+        'planningCadastre' => 'Planning and Cadastral',
+        'structure' => 'Structure',
+        'transportation' => 'Transportation',
+        'utilitiesCommunication' => 'Utilities and Communication',
+        'society' => 'Society',
+        'economy' => 'Economy'
+      }
+    end
+  end
+end

--- a/lib/schema/geoblacklight-schema.json
+++ b/lib/schema/geoblacklight-schema.json
@@ -1,0 +1,169 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "description": "Schema for GeoBlacklight as implemented for Solr 4.10+. See http://journal.code4lib.org/articles/9710 for more details. Note that the Solr schema uses dynamic typing based on the suffix of the field name. For example, _s denotes a string where _sm denotes a multi-valued string (array of strings).",
+    "id": "http://geoblacklight.org/schema",
+    "title": "GeoBlacklight Schema",
+    "required": [
+        "uuid",
+        "dc_identifier_s",
+        "dc_title_s",
+        "dc_description_s",
+        "dc_rights_s",
+        "dct_provenance_s",
+        "dct_references_s",
+        "georss_box_s",
+        "layer_id_s",
+        "layer_geom_type_s",
+        "layer_modified_dt",
+        "layer_slug_s",
+        "solr_geom",
+        "solr_year_i"
+    ],
+    "type": "object",
+    "properties": {
+        "uuid": { 
+            "type": "string", 
+            "description": "Unique identifier for layer that is globally unique."
+
+        },
+        "dc_identifier_s": {
+            "type": "string",
+            "description": "Unique identifier for layer. May be same as UUID but may be an alternate identifier."
+        },
+        "dc_title_s": { 
+            "type": "string", 
+            "description": "Title for the layer."
+
+        },
+        "dc_description_s": { 
+            "type": "string", 
+            "description": "Description for the layer."
+
+        },
+        "dc_rights_s": { 
+            "type": "string",
+            "enum": ["Public", "Restricted"], 
+            "description": "Access rights for the layer."
+
+        },
+        "dct_provenance_s": { 
+            "type": "string", 
+            "description": "Institution who holds the layer."
+
+        },
+        "dct_references_s": { 
+            "type": "string", 
+            "description": "JSON hash for external resources, where each key is a URI for the protocol or format and the value is the URL to the resource."
+
+        },
+        "georss_box_s": { 
+            "type": "string", 
+            "description": "Bounding box as maximum values for S W N E. Example: 12.6 -119.4 19.9 84.8."
+
+        },
+        "layer_id_s": { 
+            "type": "string", 
+            "description": "The complete identifier for the layer via WMS/WFS/WCS protocol. Example: druid:vr593vj7147."
+
+        },
+        "layer_geom_type_s": { 
+            "type": "string",
+            "enum": ["Point", "Line", "Polygon", "Raster", "Scanned Map", "Mixed"],
+            "description": "Geometry type for layer data, using controlled vocabulary."
+        },
+        "layer_modified_dt": { 
+            "type": "string", 
+            "format": "date-time",
+            "description": "Last modification date for the metadata record, using XML Schema dateTime format (YYYY-MM-DDThh:mm:ssZ)."
+        },
+        "layer_slug_s": { 
+            "type": "string", 
+            "description": "Unique identifier visible to the user, used for Permalinks. Example: stanford-vr593vj7147."
+
+        },
+        "solr_geom": { 
+            "type": "string",
+            "pattern": "ENVELOPE(.*,.*,.*,.*)",
+            "description": "Derived from georss_polygon_s or georss_box_s. Shape of the layer as a ENVELOPE WKT using W E N S. Example: ENVELOPE(76.76, 84.76, 19.91, 12.62). Note that this field is indexed as a Solr spatial (RPT) field."
+
+        },
+        "solr_year_i": { 
+            "type": "integer",
+            "description": "Derived from dct_temporal_sm. Year for which layer is valid and only a single value. Example: 1989. Note that this field is indexed as a Solr numeric field."
+
+        },
+        "dc_creator_sm": { 
+            "type": "array",
+            "items": {
+                 "type": "string"
+             },
+            "description": "Author(s). Example: George Washington, Thomas Jefferson."
+
+        },
+        "dc_format_s": { 
+            "type": "string", 
+            "enum": ["Shapefile", "GeoTIFF", "ArcGRID"],
+            "description": "File format for the layer, using a controlled vocabulary."
+
+        },
+        "dc_language_s": { 
+            "type": "string", 
+            "description": "Language for the layer. Example: English."
+
+        },
+        "dc_publisher_s": { 
+            "type": "string", 
+            "description": "Publisher. Example: ML InfoMap."
+
+        },
+        "dc_subject_sm": { 
+            "type": "array",
+            "items": {
+                 "type": "string"
+             },
+            "description": "Subjects, preferrably in a controlled vocabulary. Examples: Census, Human settlements."
+
+        },
+        "dc_type_s": { 
+            "type": "string",
+            "enum": ["Dataset", "Image", "PhysicalObject"],
+            "description": "Resource type, using DCMI Type Vocabulary."
+
+        },
+        "dct_spatial_sm": { 
+            "type": "array",
+            "items": {
+                 "type": "string"
+             },
+            "description": "Spatial coverage and place names, preferrably in a controlled vocabulary. Example: 'Paris, France'."
+
+        },
+        "dct_temporal_sm": { 
+            "type": "array", 
+            "items": {
+                 "type": "string"
+             },
+            "description": "Temporal coverage, typically years or dates. Example: 1989, circa 2010, 2007-2009. Note that this field is not in a specific date format."
+
+        },
+        "dct_issued_dt": { 
+            "type": "string",
+            "format": "date-time",
+            "description": "Issued date for the layer, using XML Schema dateTime format (YYYY-MM-DDThh:mm:ssZ)."
+
+        },
+        "dct_isPartOf_sm": { 
+            "type": "array",
+            "items": {
+                 "type": "string"
+             },
+            "description": "Holding dataset for the layer, such as the name of a collection. Example: Village Maps of India."
+
+        },
+        "georss_point_s": { 
+            "type": "string", 
+            "description": "Point representation for layer as y, x - i.e., centroid. Example: 12.6 -119.4."
+
+        }
+    }
+}

--- a/lib/xslt/iso2geoBL.xsl
+++ b/lib/xslt/iso2geoBL.xsl
@@ -1,6 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-     iso2geoBl.xsl - Transformation from ISO 19139 XML into GeoBlacklight solr
+     iso2geoBl.xsl - Transformation from ISO 19139 XML into GeoBlacklight solr json
      
 -->
 <xsl:stylesheet 
@@ -11,16 +10,12 @@
   xmlns:gml="http://www.opengis.net/gml"
   xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
   version="1.0" exclude-result-prefixes="gml gmd gco gmi xsl">
-  <xsl:output method="xml" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:output method="text" version="1.0" omit-xml-declaration="yes" indent="no" media-type="application/json"/>
   <xsl:strip-space elements="*"/>
   <xsl:param name="geometryType"/>
   <xsl:param name="purl"/>
   <xsl:param name="zipName" select="'data.zip'"/>
-  
-  
 
-
-  
   <xsl:template match="/">
     <!-- institution  -->
     <xsl:variable name="institution">
@@ -102,25 +97,12 @@
         </xsl:otherwise>
          </xsl:choose>
     </xsl:variable>
-    <add>
-      <doc>
-        <field name="uuid">
-          <xsl:value-of select="$uuid"/>
-        </field>
-       
-        <field name="dc_identifier_s">
-          <xsl:value-of select="$uuid"/>
-        </field>
-        
-        <field name="dc_title_s">
-          <xsl:value-of select="gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:title"/>
-        </field>
-
-        <field name="dc_description_s">
-          <xsl:value-of select="gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:abstract"/>
-        </field>
-        
-        <field name="dc_rights_s">
+    <xsl:text>{</xsl:text>
+      <xsl:text>"uuid": "</xsl:text><xsl:value-of select="$uuid"/><xsl:text>",</xsl:text>
+      <xsl:text>"dc_identifier_s": "</xsl:text><xsl:value-of select="$uuid"/><xsl:text>",</xsl:text>
+      <xsl:text>"dc_title_s": "</xsl:text><xsl:value-of select="gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:title"/><xsl:text>",</xsl:text>
+      <xsl:text>"dc_description_s": "</xsl:text><xsl:value-of select="gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:abstract"/><xsl:text>",</xsl:text>
+      <xsl:text>"dc_rights_s": "</xsl:text>
           <xsl:choose>
             <xsl:when test="gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:resourceConstraints/gmd:MD_LegalConstraints/gmd:accessConstraints/gmd:MD_RestrictionCode[@codeListValue='restricted']">
               <xsl:text>Restricted</xsl:text>
@@ -150,97 +132,56 @@
             <xsl:otherwise>
               <xsl:text>Public</xsl:text>
             </xsl:otherwise>
-          </xsl:choose>
-        </field>
-
-        <field name="dct_provenance_s">
-          <xsl:value-of select="$institution"/>
-        </field>
-
-        <field name="dct_references_s">
-          <xsl:text>{</xsl:text>
-          <xsl:text>"http://schema.org/url":"</xsl:text>              
-          <xsl:value-of select="$uuid"/>
-          <xsl:text>",</xsl:text>
-          <!--<xsl:text>"http://schema.org/thumbnailUrl":"</xsl:text>              
-          <xsl:value-of select="$stacks_root"/>
-          <xsl:text>/file/druid:</xsl:text>
-          <xsl:value-of select="$identifier"/>
-          <xsl:text>/preview.jpg",</xsl:text>
-          <xsl:text>"http://schema.org/DownloadAction":"</xsl:text>              
-          <xsl:value-of select="$stacks_root"/>
-          <xsl:text>/file/druid:</xsl:text>
-          <xsl:value-of select="$identifier"/>
-          <xsl:text>/data.zip",</xsl:text>
-          <xsl:text>"http://www.loc.gov/mods/v3":"</xsl:text>              
-          <xsl:text>http://earthworks.stanford.edu/opengeometadata/layers/edu.stanford.purl/</xsl:text>
-          <xsl:value-of select="$identifier"/>
-          <xsl:text>/mods",</xsl:text>
-          <xsl:text>"http://www.isotc211.org/schemas/2005/gmd/":"</xsl:text>              
-          <xsl:text>http://earthworks.stanford.edu/opengeometadata/layers/edu.stanford.purl/</xsl:text>
-          <xsl:value-of select="$identifier"/>
-          <xsl:text>/iso19139",</xsl:text>
-          <xsl:text>"http://www.opengis.net/def/serviceType/ogc/wms":"</xsl:text>
-          <xsl:value-of select="$geoserver_root"/>
-          <xsl:text>/wms",</xsl:text>
-          <xsl:text>"http://www.opengis.net/def/serviceType/ogc/wfs":"</xsl:text>
-          <xsl:value-of select="$geoserver_root"/>
-          <xsl:text>/wfs",</xsl:text>
-          <xsl:text>"http://www.opengis.net/def/serviceType/ogc/wcs":"</xsl:text>
-          <xsl:value-of select="$geoserver_root"/>
-          <xsl:text>/wcs"</xsl:text> -->
-          <xsl:text>}</xsl:text>
-        </field>
-
-        <field name="layer_id_s">
-          <xsl:choose>
-            <xsl:when test="$institution = 'Stanford'">
-              <xsl:text>druid:</xsl:text>
-              <xsl:value-of select="$identifier"/>
-            </xsl:when>
-            <xsl:otherwise>
-              <xsl:text>urn:</xsl:text>
-              <xsl:value-of select="$identifier"/>
-            </xsl:otherwise>
-          </xsl:choose>
-        </field>
-        
-        <field name="layer_slug_s">
-          <xsl:value-of select="$institution"/>
-          <xsl:text>-</xsl:text>
-          <xsl:value-of select="$identifier"/>
-        </field>
-
-        <field name="layer_geom_type_s">
-          <xsl:value-of select="$geometryType"/>
-        </field>
-        
+          </xsl:choose><xsl:text>",</xsl:text>
+      <xsl:text>"dct_provenance_s": "</xsl:text><xsl:value-of select="$institution"/>",
+      
+      <xsl:text>"layer_id_s": "</xsl:text>
+        <xsl:choose>
+          <xsl:when test="$institution = 'Stanford'">
+            <xsl:text>druid:</xsl:text>
+            <xsl:value-of select="$identifier"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:text>urn:</xsl:text>
+            <xsl:value-of select="$identifier"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      <xsl:text>",</xsl:text>
+      <xsl:text>"layer_slug_s": "</xsl:text>
+        <xsl:value-of select="$institution"/>
+        <xsl:text>-</xsl:text>
+        <xsl:value-of select="$identifier"/>
+      <xsl:text>",</xsl:text>
+      <xsl:text>"layer_geom_type_s": "</xsl:text><xsl:value-of select="$geometryType"/><xsl:text>",</xsl:text>
+      
         <xsl:choose>
           <xsl:when test="contains(gmd:MD_Metadata/gmd:dateStamp, 'T')">
-            <field name="layer_modified_dt">
+            <xsl:text>"layer_modified_dt": "</xsl:text>
               <xsl:value-of select="substring-before(gmd:MD_Metadata/gmd:dateStamp, 'T')"/>
-            </field>
+              <xsl:text>",</xsl:text>
           </xsl:when>
           <xsl:when test="gmd:MD_Metadata/gmd:dateStamp">
-            <field name="layer_modified_dt">
+            <xsl:text>"layer_modified_dt": "</xsl:text>
               <xsl:value-of select="gmd:MD_Metadata/gmd:dateStamp"/>
-            </field>
+              <xsl:text>",</xsl:text>
           </xsl:when>
         </xsl:choose>
 
-        <xsl:for-each select="gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty">  
+        <!-- <xsl:for-each select="gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty">  
           <xsl:choose>
             <xsl:when test="gmd:role/gmd:CI_RoleCode[@codeListValue='originator']">
+              <xsl:text>"dc_creator_sm": [</xsl:text>
               <xsl:for-each select="gmd:organisationName">
-                <field name="dc_creator_sm">
+                <xsl:text>"</xsl:text>
                   <xsl:value-of select="."/>
-                </field>
+                <xsl:text>",</xsl:text>
               </xsl:for-each>
               <xsl:for-each select="gmd:individualName">
-                <field name="dc_creator_sm">
+                <xsl:text>"</xsl:text>
                   <xsl:value-of select="."/>
-                </field>
+                <xsl:text>",</xsl:text>
               </xsl:for-each>
+              <xsl:text>],</xsl:text>
             </xsl:when>
             
             <xsl:when test="gmd:role/gmd:CI_RoleCode[@codeListValue='publisher']">
@@ -257,165 +198,109 @@
             </xsl:when>
           </xsl:choose>
         </xsl:for-each>
-        
-        <field name="dc_format_s">
-          <xsl:value-of select="$format"/>
-        </field>
+         -->
+
+        <xsl:text>"dc_format_s": "</xsl:text><xsl:value-of select="$format"/><xsl:text>",</xsl:text>
         
         <!-- TODO: add inputs for other languages -->
-        <field name="dc_language_s">
+        <!-- <field name="dc_language_s">
           <xsl:if test="contains(gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:language | gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:language/gmd:LanguageCode, 'eng')">
             <xsl:text>English</xsl:text>
           </xsl:if>
-        </field>
+        </field> -->
         
         <!-- from DCMI type vocabulary -->
         <xsl:choose>
           <xsl:when test="contains(gmd:MD_Metadata/gmd:hierarchyLevelName/gco:CharacterString, 'dataset')">
-            <field name="dc_type_s">
-              <xsl:text>Dataset</xsl:text>
-            </field>
+            <xsl:text>"dc_type_s": "Dataset",</xsl:text>
           </xsl:when>
 
           <xsl:when test="contains(gmd:MD_Metadata/gmd:hierarchyLevelName/gco:CharacterString, 'service')">
-            <field name="dc_type_s">
-              <xsl:text>Service</xsl:text>
-            </field>
+            <xsl:text>"dc_type_s": "Service",</xsl:text>
           </xsl:when>
        </xsl:choose>
 
         <!-- translate ISO topic categories -->
-        <xsl:for-each select="gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:topicCategory/gmd:MD_TopicCategoryCode">
-          <field name="dc_subject_sm">
-            <xsl:choose>
-              <xsl:when test="contains(.,'farming')">
-                <xsl:text>Farming</xsl:text>
-              </xsl:when>
-              <xsl:when test="contains(.,'biota')">
-                <xsl:text>Biology and Ecology</xsl:text>
-              </xsl:when>
-              <xsl:when test="contains(.,'climatologyMeteorologyAtmosphere')">
-                <xsl:text>Climatology, Meteorology and Atmosphere</xsl:text>
-              </xsl:when>
-              <xsl:when test="contains(.,'boundaries')">
-                <xsl:text>Boundaries</xsl:text>
-              </xsl:when>
-              <xsl:when test="contains(.,'elevation')">
-                <xsl:text>Elevation</xsl:text>
-              </xsl:when>
-              <xsl:when test="contains(.,'environment')">
-                <xsl:text>Environment</xsl:text>
-              </xsl:when>
-              <xsl:when test="contains(.,'geoscientificInformation')">
-                <xsl:text>Geoscientific Information</xsl:text>
-              </xsl:when>
-              <xsl:when test="contains(.,'health')">
-                <xsl:text>Health</xsl:text>
-              </xsl:when>
-              <xsl:when test="contains(.,'imageryBaseMapsEarthCover')">
-                <xsl:text>Imagery and Base Maps</xsl:text>
-              </xsl:when>
-              <xsl:when test="contains(.,'intelligenceMilitary')">
-                <xsl:text>Military</xsl:text>
-              </xsl:when>
-              <xsl:when test="contains(.,'inlandWaters')">
-                <xsl:text>Inland Waters</xsl:text>
-              </xsl:when>
-              <xsl:when test="contains(.,'location')">
-                <xsl:text>Location</xsl:text>
-              </xsl:when>
-              <xsl:when test="contains(.,'oceans')">
-                <xsl:text>Oceans</xsl:text>
-              </xsl:when>
-              <xsl:when test="contains(.,'planningCadastre')">
-                <xsl:text>Planning and Cadastral</xsl:text>
-              </xsl:when>
-              <xsl:when test="contains(.,'structure')">
-                <xsl:text>Structure</xsl:text>
-              </xsl:when>
-              <xsl:when test="contains(.,'transportation')">
-                <xsl:text>Transportation</xsl:text>
-              </xsl:when>
-              <xsl:when test="contains(.,'utilitiesCommunication')">
-                <xsl:text>Utilities and Communication</xsl:text>
-              </xsl:when>
-              <xsl:when test="contains(.,'society')">
-                <xsl:text>Society</xsl:text>
-              </xsl:when>
-              <xsl:when test="contains(.,'economy')">
-                <xsl:text>Economy</xsl:text>
-              </xsl:when>
-              <xsl:otherwise>
-                <xsl:value-of select="."/>
-              </xsl:otherwise>
-            </xsl:choose>
-          </field>
-        </xsl:for-each>
+        <xsl:if test="gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:topicCategory/gmd:MD_TopicCategoryCode or gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:descriptiveKeywords/gmd:MD_Keywords">
+          <xsl:text>"dc_subject_sm": [</xsl:text>
+            <xsl:for-each select="gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:topicCategory/gmd:MD_TopicCategoryCode">
+              <xsl:text>"</xsl:text>              
+                  <xsl:value-of select="."/>
+                <xsl:text>"</xsl:text>
+              <xsl:if test="position() != last()">
+                <xsl:text>,</xsl:text>
+              </xsl:if>
+            </xsl:for-each>
+          <xsl:text>],</xsl:text>
+        </xsl:if>
         
         <xsl:for-each select="gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:descriptiveKeywords/gmd:MD_Keywords">
           <xsl:choose>
-            <xsl:when test="gmd:type/gmd:MD_KeywordTypeCode[@codeListValue='theme']">
+            <!-- <xsl:when test="gmd:type/gmd:MD_KeywordTypeCode[@codeListValue='theme']">
               <xsl:for-each select="gmd:keyword">
                 <field name="dc_subject_sm">
                   <xsl:value-of select="."/>
                 </field>
               </xsl:for-each>
-            </xsl:when>
+            </xsl:when> -->
 
             <xsl:when test="gmd:type/gmd:MD_KeywordTypeCode[@codeListValue='place']">
+              <xsl:text>"dc_spatial_sm": [</xsl:text>
               <xsl:for-each select="gmd:keyword">
-                <field name="dc_spatial_sm">
-                  <xsl:value-of select="."/>
-                </field>
+                <xsl:text>"</xsl:text><xsl:value-of select="."/><xsl:text>"</xsl:text>
+                  <xsl:if test="position() != last()">
+                    <xsl:text>,</xsl:text>
+                  </xsl:if>
               </xsl:for-each>
+              <xsl:text>],</xsl:text>
             </xsl:when>
           </xsl:choose>
         </xsl:for-each>
 
         <xsl:choose>
           <xsl:when test="contains(gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:date/gmd:CI_Date/gmd:date/gco:DateTime, 'T')">
-            <field name="dct_issued_s">
+            <xsl:text>"dct_issued_s": "</xsl:text>
               <xsl:value-of select="substring-before(gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:date/gmd:CI_Date/gmd:date/gco:DateTime,'T')"/>
-            </field>
+            <xsl:text>",</xsl:text>
           </xsl:when>
 
           <xsl:when test="gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:date/gmd:CI_Date/gmd:date/gco:DateTime">
-            <field name="dct_issued_s">
+            <xsl:text>"dct_issued_s": "</xsl:text>
               <xsl:value-of select="gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:date/gmd:CI_Date/gmd:date/gco:DateTime"/>
-            </field>
+            <xsl:text>",</xsl:text>
           </xsl:when>
 
           <xsl:when test="gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:date/gmd:CI_Date/gmd:date/gco:Date">
-            <field name="dct_issued_s">
+            <xsl:text>"dct_issued_s": "</xsl:text>
               <xsl:value-of select="gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:date/gmd:CI_Date/gmd:date/gco:Date"/>
-            </field>
+            <xsl:text>",</xsl:text>
           </xsl:when>
-  
-          <xsl:otherwise>unknown</xsl:otherwise>
+          
+          <!-- <xsl:otherwise>unknown</xsl:otherwise> -->
         </xsl:choose>
         
         
       <!-- content date: range YYYY-YYYY if dates differ  -->
         <xsl:choose>
           <xsl:when test="gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:extent/gmd:EX_Extent/gmd:temporalElement/gmd:EX_TemporalExtent/gmd:extent/gml:TimePeriod/gml:beginPosition/text() != ''">
-            <field name="dct_temporal_sm">
-            <xsl:value-of select="substring(gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:extent/gmd:EX_Extent/gmd:temporalElement/gmd:EX_TemporalExtent/gmd:extent/gml:TimePeriod/gml:beginPosition, 1,4)"/>
-            <xsl:if test="substring(gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:extent/gmd:EX_Extent/gmd:temporalElement/gmd:EX_TemporalExtent/gmd:extent/gml:TimePeriod/gml:endPosition, 1,4) != substring(gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:extent/gmd:EX_Extent/gmd:temporalElement/gmd:EX_TemporalExtent/gmd:extent/gml:TimePeriod/gml:beginPosition,1,4)">  
-            <xsl:text>-</xsl:text>
-            <xsl:value-of select="substring(gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:extent/gmd:EX_Extent/gmd:temporalElement/gmd:EX_TemporalExtent/gmd:extent/gml:TimePeriod/gml:endPosition, 1,4)"/>
-            </xsl:if>
-            </field>
+            <xsl:text>"dct_temporal_sm": "</xsl:text>
+              <xsl:value-of select="substring(gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:extent/gmd:EX_Extent/gmd:temporalElement/gmd:EX_TemporalExtent/gmd:extent/gml:TimePeriod/gml:beginPosition, 1,4)"/>
+              <xsl:if test="substring(gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:extent/gmd:EX_Extent/gmd:temporalElement/gmd:EX_TemporalExtent/gmd:extent/gml:TimePeriod/gml:endPosition, 1,4) != substring(gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:extent/gmd:EX_Extent/gmd:temporalElement/gmd:EX_TemporalExtent/gmd:extent/gml:TimePeriod/gml:beginPosition,1,4)">  
+                <xsl:text>-</xsl:text>
+              <xsl:value-of select="substring(gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:extent/gmd:EX_Extent/gmd:temporalElement/gmd:EX_TemporalExtent/gmd:extent/gml:TimePeriod/gml:endPosition, 1,4)"/>
+              </xsl:if>
+              <xsl:text>",</xsl:text>
           </xsl:when>
             
             <xsl:when test="gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:extent/gmd:EX_Extent/gmd:temporalElement/gmd:EX_TemporalExtent/gmd:extent/gml:TimeInstant">
-              <field name="dct_temporal_sm">
-              <xsl:value-of select="substring(gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:extent/gmd:EX_Extent/gmd:temporalElement/gmd:EX_TemporalExtent/gmd:extent/gml:TimeInstant, 1,4)"/>
-              </field> 
+              <xsl:text>"dct_temporal_sm": "</xsl:text>
+                <xsl:value-of select="substring(gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:extent/gmd:EX_Extent/gmd:temporalElement/gmd:EX_TemporalExtent/gmd:extent/gml:TimeInstant, 1,4)"/>
+              <xsl:text>",</xsl:text>
             </xsl:when>
           </xsl:choose>
         
         <!-- collection -->
-        <xsl:choose>
+        <!-- <xsl:choose>
           <xsl:when test="gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:aggregationInfo/gmd:MD_AggregateInformation/gmd:associationType/gmd:DS_AssociationTypeCode[@codeListValue='largerWorkCitation']">
             <xsl:for-each select="gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:aggregationInfo/gmd:MD_AggregateInformation/gmd:associationType/gmd:DS_AssociationTypeCode[@codeListValue='largerWorkCitation']">
             <field name="dct_isPartOf_sm">
@@ -430,16 +315,23 @@
             </field>
             </xsl:for-each>
           </xsl:when>
-        </xsl:choose>
+        </xsl:choose> -->
      
         <!-- cross-references -->
-        <xsl:for-each select="gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:aggregationInfo/gmd:MD_AggregateInformation/gmd:associationType/gmd:DS_AssociationTypeCode[@codeListValue='crossReference']">
-           <field name="dc_relation_sm">
-             <xsl:value-of select="ancestor-or-self::*/gmd:aggregateDataSetName/gmd:CI_Citation/gmd:title"/>
-           </field>
-         </xsl:for-each>
+        <xsl:if test="gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:aggregationInfo/gmd:MD_AggregateInformation/gmd:associationType/gmd:DS_AssociationTypeCode[@codeListValue='crossReference']">
+          <xsl:text>"dc_relation_sm": [</xsl:text> 
+          <xsl:for-each select="gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:aggregationInfo/gmd:MD_AggregateInformation/gmd:associationType/gmd:DS_AssociationTypeCode[@codeListValue='crossReference']">            
+            <xsl:text>"</xsl:text>
+              <xsl:value-of select="ancestor-or-self::*/gmd:aggregateDataSetName/gmd:CI_Citation/gmd:title"/>
+            <xsl:text>"</xsl:text>
+            <xsl:if test="position() != last()">
+              <xsl:text>,</xsl:text>
+            </xsl:if>
+           </xsl:for-each>
+        </xsl:if>
         
           <field name="georss_polygon_s">
+        <xsl:text>"georss_polygon_s": "</xsl:text> 
           <xsl:text></xsl:text>
           <xsl:value-of select="$y1"/>
           <xsl:text> </xsl:text>
@@ -460,10 +352,9 @@
           <xsl:value-of select="$y1"/>
           <xsl:text> </xsl:text>
           <xsl:value-of select="$x1"/>
-        </field>
+        <xsl:text>",</xsl:text>
         
-        <field name="solr_geom">
-          <xsl:text>ENVELOPE(</xsl:text>
+          <xsl:text>"solr_geom": "ENVELOPE(</xsl:text>
           <xsl:value-of select="$x1"/>
           <xsl:text> </xsl:text>
           <xsl:value-of select="$y1"/>
@@ -483,10 +374,9 @@
           <xsl:value-of select="$x1"/>
           <xsl:text> </xsl:text>
           <xsl:value-of select="$y1"/>
-          <xsl:text>)</xsl:text>
-        </field>
+          <xsl:text>)",</xsl:text>
         
-        <field name="georss_box_s">
+        <xsl:text>"georss_box_s": "</xsl:text>
           <xsl:value-of select="$y1"/>
           <xsl:text> </xsl:text>
           <xsl:value-of select="$x1"/>
@@ -494,23 +384,20 @@
           <xsl:value-of select="$y2"/>
           <xsl:text> </xsl:text>
           <xsl:value-of select="$x2"/>
-        </field>
-              
+        <xsl:text>",</xsl:text>
+        
         <!-- content date: singular, or beginning date of range: YYYY -->
         <xsl:choose>
           <xsl:when test="gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:extent/gmd:EX_Extent/gmd:temporalElement/gmd:EX_TemporalExtent/gmd:extent/gml:TimePeriod/gml:beginPosition/text() != ''">
-            <field name="solr_year_i">
+            <xsl:text>"solr_year_i": </xsl:text>
               <xsl:value-of select="substring(gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:extent/gmd:EX_Extent/gmd:temporalElement/gmd:EX_TemporalExtent/gmd:extent/gml:TimePeriod/gml:beginPosition, 1,4)"/>
-            </field>         
           </xsl:when>
           <xsl:when test="gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:extent/gmd:EX_Extent/gmd:temporalElement/gmd:EX_TemporalExtent/gmd:extent/gml:TimeInstant">
-            <field name="solr_year_i">
+            <xsl:text>"solr_year_i": </xsl:text>
               <xsl:value-of select="substring(gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:extent/gmd:EX_Extent/gmd:temporalElement/gmd:EX_TemporalExtent/gmd:extent/gml:TimeInstant, 1,4)"/>
-            </field> 
           </xsl:when>
         </xsl:choose>
-      </doc>
-    </add>
+      <xsl:text>}</xsl:text>
   </xsl:template>
 
 </xsl:stylesheet>

--- a/spec/fixtures/docs/basic_geoblacklight.json
+++ b/spec/fixtures/docs/basic_geoblacklight.json
@@ -1,0 +1,29 @@
+{  
+  "uuid":"http://purl.stanford.edu/bb338jh0716",
+  "dc_identifier_s":"http://purl.stanford.edu/bb338jh0716",
+  "dc_title_s":"Hydrologic Sub-Area Boundaries: Russian River Watershed, California, 1999",
+  "dc_description_s":"This polygon dataset represents the Hydrologic Sub-Area boundaries for the Russian River basin, as defined by the Calwater 2.2a watershed boundaries. The original CALWATER22 layer (Calwater 2.2a watershed boundaries) was developed as a coverage named calw22a and is administered by the Interagency California Watershed Mapping Committee (ICWMC). ",
+  "dc_rights_s":"Public",
+  "dct_provenance_s":"Stanford",
+  "layer_id_s":"druid:bb338jh0716",
+  "layer_slug_s":"Stanford-bb338jh0716",
+  "layer_geom_type_s":"",
+  "layer_modified_dt":"2014-10-08",
+  "dc_format_s":"application/x-esri-shapefile",
+  "dc_type_s":"Dataset",
+  "dc_subject_sm":[  
+    "boundaries",
+    "inlandWaters"
+  ],
+  "dc_spatial_sm":[  
+    "Sonoma County (Calif.)",
+    "Mendocino County (Calif.)",
+    "Russian River Watershed (Calif.)"
+  ],
+  "dct_issued_s":"2002-09-01",
+  "dct_temporal_sm":"1999",
+  "georss_polygon_s":"38.298024 -123.387866 39.399217 -123.387866 39.399217 -122.522658 38.298024 -122.522658 38.298024 -123.387866",
+  "solr_geom":"ENVELOPE(-123.387866 38.298024, -122.522658 38.298024, -122.522658 39.399217, -123.387866 39.399217, -123.387866 38.298024)",
+  "georss_box_s":"38.298024 -123.387866 39.399217 -122.522658",
+  "solr_year_i":1999
+}

--- a/spec/fixtures/docs/full_geoblacklight.json
+++ b/spec/fixtures/docs/full_geoblacklight.json
@@ -1,0 +1,39 @@
+{
+  "uuid":"http://purl.stanford.edu/cz128vq0535",
+  "dc_identifier_s":"http://purl.stanford.edu/cz128vq0535",
+  "dc_title_s":"2005 Rural Poverty GIS Database: Uganda",
+  "dc_description_s":"This polygon shapefile contains 2005 poverty data for 855 rural subcounties in Uganda. These data are intended for researchers, students, policy makers and the general public for reference and mapping purposes, and may be used for basic applications such as viewing, querying, and map output production.",
+  "dc_rights_s":"Public",
+  "dct_provenance_s":"Stanford",
+  "dct_references_s":"{\"http://schema.org/url\":\"http://purl.stanford.edu/cz128vq0535\",\"http://schema.org/downloadUrl\":\"http://stacks.stanford.edu/file/druid:cz128vq0535/data.zip\",\"http://www.loc.gov/mods/v3\":\"http://purl.stanford.edu/cz128vq0535.mods\",\"http://www.isotc211.org/schemas/2005/gmd/\":\"http://opengeometadata.stanford.edu/metadata/edu.stanford.purl/druid:cz128vq0535/iso19139.xml\",\"http://www.w3.org/1999/xhtml\":\"http://opengeometadata.stanford.edu/metadata/edu.stanford.purl/druid:cz128vq0535/default.html\",\"http://www.opengis.net/def/serviceType/ogc/wfs\":\"https://geowebservices.stanford.edu/geoserver/wfs\",\"http://www.opengis.net/def/serviceType/ogc/wms\":\"https://geowebservices.stanford.edu/geoserver/wms\"}",
+  "layer_id_s":"druid:cz128vq0535",
+  "layer_slug_s":"stanford-cz128vq0535",
+  "layer_geom_type_s":"Polygon",
+  "layer_modified_dt":"2015-01-13T18:46:38Z",
+  "dc_format_s":"Shapefile",
+  "dc_language_s":"English",
+  "dc_type_s":"Dataset",
+  "dc_publisher_s":"Uganda Bureau of Statistics",
+  "dc_creator_sm":[
+    "Uganda Bureau of Statistics"
+  ],
+  "dc_subject_sm":[
+    "Poverty",
+    "Statistics"
+  ],
+  "dct_issued_s":"2005",
+  "dct_temporal_sm":[
+    "2005"
+  ],
+  "dct_spatial_sm":[
+    "Uganda"
+  ],
+  "dc_relation_sm":[
+    "http://sws.geonames.org/226074/about.rdf"
+  ],
+  "georss_box_s":"-1.478794 29.572742 4.234077 35.000308",
+  "georss_polygon_s":"-1.478794 29.572742 4.234077 29.572742 4.234077 35.000308 -1.478794 35.000308 -1.478794 29.572742",
+  "solr_geom":"ENVELOPE(29.572742, 35.000308, 4.234077, -1.478794)",
+  "solr_bbox":"29.572742 -1.478794 35.000308 4.234077",
+  "solr_year_i":2005
+}

--- a/spec/fixtures/json_docs.rb
+++ b/spec/fixtures/json_docs.rb
@@ -1,0 +1,15 @@
+##
+# JSON docs that can be included into specs
+module JsonDocs
+  ##
+  # A basic incomplete, non-compliant GeoBlacklight-Schema json document
+  def basic_geoblacklight
+    File.read(File.join(File.dirname(__FILE__), './docs/basic_geoblacklight.json'))
+  end
+
+  ##
+  # A fully compliant GeoBlacklight-Schema json document
+  def full_geoblacklight
+    File.read(File.join(File.dirname(__FILE__), './docs/full_geoblacklight.json'))
+  end
+end

--- a/spec/fixtures/xml_docs.rb
+++ b/spec/fixtures/xml_docs.rb
@@ -698,50 +698,6 @@ module XmlDocs
   end
 
   ##
-  # Example GeoBlacklight XML from 
-  def stanford_geobl
-    <<-xml
-      <?xml version="1.0" encoding="UTF-8"?>
-      <add xmlns="http://lucene.apache.org/solr/4/document">
-      <doc>
-        <field name="uuid">http://purl.stanford.edu/bb338jh0716</field>
-        <field name="dc_identifier_s">http://purl.stanford.edu/bb338jh0716</field>
-        <field name="dc_title_s">Hydrologic Sub-Area Boundaries: Russian River Watershed, California, 1999</field>
-        <field name="dc_description_s">This polygon dataset represents the Hydrologic Sub-Area boundaries for the Russian River basin, as defined by the Calwater 2.2a watershed boundaries. The original CALWATER22 layer (Calwater 2.2a watershed boundaries) was developed as a coverage named calw22a and is administered by the Interagency California Watershed Mapping Committee (ICWMC). This shapefile can be used to map and analyze data at the Hydrologic Sub-Area scale.</field>
-        <field name="dc_rights_s">Restricted</field>
-        <field name="dct_provenance_s">Stanford</field>
-        <field name="dct_references_s">{"http://schema.org/url":"http://opengeometadata.stanford.edu/metadata/edu.stanford.purl/druid:bb338jh0716/default.html","http://www.loc.gov/mods/v3":"http://purl.stanford.edu/bb338jh0716.mods","http://www.isotc211.org/schemas/2005/gmd/":"http://opengeometadata.stanford.edu/metadata/edu.stanford.purl/druid:bb338jh0716/iso19139.xml","http://www.w3.org/1999/xhtml":"http://opengeometadata.stanford.edu/metadata/edu.stanford.purl/druid:bb338jh0716/default.html","http://www.opengis.net/def/serviceType/ogc/wfs":"https://geowebservices-restricted.stanford.edu/geoserver/wfs","http://www.opengis.net/def/serviceType/ogc/wms":"https://geowebservices-restricted.stanford.edu/geoserver/wms"}</field>
-        <field name="layer_id_s">druid:bb338jh0716</field>
-        <field name="layer_slug_s">stanford-bb338jh0716</field>
-        <field name="layer_geom_type_s">Polygon</field>
-        <field name="layer_modified_dt">2014-12-16T19:30:53Z</field>
-        <field name="dc_format_s">Shapefile</field>
-        <field name="dc_language_s">English</field>
-        <field name="dc_type_s">Dataset</field>
-        <field name="dc_publisher_s">Circuit Rider Productions</field>
-        <field name="dc_creator_sm">Circuit Rider Productions</field>
-        <field name="dc_subject_sm">Hydrology</field>
-        <field name="dc_subject_sm">Watersheds</field>
-        <field name="dc_subject_sm">Boundaries</field>
-        <field name="dc_subject_sm">Inland Waters</field>
-        <field name="dct_issued_s">2002</field>
-        <field name="dct_temporal_sm">1999</field>
-        <field name="dct_spatial_sm">Sonoma County (Calif.)</field>
-        <field name="dct_spatial_sm">Mendocino County (Calif.)</field>
-        <field name="dct_spatial_sm">Russian River Watershed (Calif.)</field>
-        <field name="dc_relation_sm">http://sws.geonames.org/5397100/about.rdf</field>
-        <field name="dc_relation_sm">http://sws.geonames.org/5372163/about.rdf</field>
-        <field name="georss_box_s">38.298673 -123.387626 39.399103 -122.528843</field>
-        <field name="georss_polygon_s">38.298673 -123.387626 39.399103 -123.387626 39.399103 -122.528843 38.298673 -122.528843 38.298673 -123.387626</field>
-        <field name="solr_geom">ENVELOPE(-123.387626, -122.528843, 39.399103, 38.298673)</field>
-        <field name="solr_bbox">-123.387626 38.298673 -122.528843 39.399103</field>
-        <field name="solr_year_i">1999</field>
-      </doc>
-      </add>
-    xml
-  end
-
-  ##
   # Example FGDC XML from https://github.com/OpenGeoMetadata/edu.tufts/blob/master/0/108/220/208/fgdc.xml
   def tufts_fgdc
     <<-xml

--- a/spec/lib/geo_combine/geoblacklight_spec.rb
+++ b/spec/lib/geo_combine/geoblacklight_spec.rb
@@ -8,6 +8,11 @@ RSpec.describe GeoCombine::Geoblacklight do
       expect(valid_json?(geobl_object.to_json)).to be_truthy
     end
   end
+  describe '#valid?' do
+    pending 'geoblacklight object should be valid' do
+      expect(geobl_object.valid?).to be_truthy
+    end
+  end
   describe '#to_hash' do
     it 'returns a hash' do
       expect(geobl_object.to_hash).to be_an Hash

--- a/spec/lib/geo_combine/geoblacklight_spec.rb
+++ b/spec/lib/geo_combine/geoblacklight_spec.rb
@@ -2,20 +2,52 @@ require 'spec_helper'
 
 RSpec.describe GeoCombine::Geoblacklight do
   include XmlDocs
-  let(:geobl_object){ GeoCombine::Geoblacklight.new(stanford_geobl) }
+  include JsonDocs
+  let(:full_geobl) { GeoCombine::Geoblacklight.new(full_geoblacklight) }
+  let(:basic_geobl) { GeoCombine::Geoblacklight.new(basic_geoblacklight) }
+  describe '#initialize' do
+    it 'parses metadata argument JSON to Hash' do
+      expect(basic_geobl.instance_variable_get(:@metadata)).to be_an Hash
+    end
+    describe 'merges fields argument into metadata' do
+      let(:basic_geobl) { GeoCombine::Geoblacklight.new(basic_geoblacklight, 'uuid' => 'new one', "extra_field" => true)}
+      it 'overwrites existing metadata fields' do
+        expect(basic_geobl.metadata['uuid']).to eq 'new one'
+      end
+      it 'adds in new fields' do
+        expect(basic_geobl.metadata['extra_field']).to be true
+      end
+    end
+  end
+  describe '#metadata' do
+    it 'reads the metadata instance variable' do
+      expect(basic_geobl.metadata).to be_an Hash
+      expect(basic_geobl.metadata).to have_key 'uuid'
+    end
+  end
   describe '#to_json' do
     it 'returns valid json' do
-      expect(valid_json?(geobl_object.to_json)).to be_truthy
+      expect(valid_json?(full_geobl.to_json)).to be_truthy
+      expect(valid_json?(basic_geobl.to_json)).to be_truthy
+    end
+  end
+  describe '#enhance_metadata' do
+    let(:enhanced_geobl) { GeoCombine::Geoblacklight.new(basic_geoblacklight, 'dct_references_s' => '', 'layer_geom_type_s' => 'Polygon') }
+    before { enhanced_geobl.enhance_metadata }
+    it 'calls enhancement methods to validate document' do
+      expect { basic_geobl.valid? }.to raise_error JSON::Schema::ValidationError
+      expect(enhanced_geobl.valid?).to be true
+    end
+    it 'enhances the dc_subject_sm field' do
+      expect(enhanced_geobl.metadata['dc_subject_sm']).to include 'Boundaries', 'Inland Waters'
     end
   end
   describe '#valid?' do
-    pending 'geoblacklight object should be valid' do
-      expect(geobl_object.valid?).to be_truthy
+    it 'a valid geoblacklight-schema document should be valid' do
+      expect(full_geobl.valid?).to be true
     end
-  end
-  describe '#to_hash' do
-    it 'returns a hash' do
-      expect(geobl_object.to_hash).to be_an Hash
+    it 'an invalid document' do
+      expect { basic_geobl.valid? }.to raise_error JSON::Schema::ValidationError
     end
   end
 end

--- a/spec/lib/geo_combine/iso19139_spec.rb
+++ b/spec/lib/geo_combine/iso19139_spec.rb
@@ -19,8 +19,13 @@ RSpec.describe GeoCombine::Iso19139 do
     end
   end
   describe '#to_geoblacklight' do
+    let(:valid_geoblacklight) { iso_object.to_geoblacklight('layer_geom_type_s' => 'Polygon', 'dct_references_s' => '') }
     it 'should create a GeoCombine::Geoblacklight object' do
-      expect(iso_object.to_geoblacklight).to be_an GeoCombine::Geoblacklight
+      expect(valid_geoblacklight).to be_an GeoCombine::Geoblacklight
+    end
+    it 'is valid GeoBlacklight-Schema' do
+      valid_geoblacklight.enhance_metadata
+      expect(valid_geoblacklight.valid?).to be_truthy
     end
   end
   describe '#to_html' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,6 +21,7 @@ Coveralls.wear!
 
 require 'geo_combine'
 require 'fixtures/xml_docs'
+require 'fixtures/json_docs'
 require 'helpers'
 
 RSpec.configure do |config|


### PR DESCRIPTION
This pull request significantly improves support for GeoBlacklight-Schema. GeoBlacklight-Schema has moved away from being xml based to JSON based and this pull request modifies GeoCombine with this change in mind by doing the following.

 - it creates a way to validate geoblacklight-schema json using the schema validation from https://github.com/geoblacklight/geoblacklight-schema/blob/master/geoblacklight-schema.json
 - it modifies `iso2geoBL.xsl` to output json that is almost compliant geoblacklight-schema
 - provides a way to create `GeoCombine::Geoblacklight` objects that do the following:
   - can be created with a valid JSON string of geoblacklight-schema
   - output valid json using `#to_json`
   - can take a `fields` argument as a `Hash` that merges with the original metadata
   - provides an `#enhance_metadata` method that does some enhancements, and translations on geoblacklight-schema metadata