### PR TITLE
Creates semantically valid iso19139 to html

### DIFF
--- a/geo_combine.gemspec
+++ b/geo_combine.gemspec
@@ -25,4 +25,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency 'rspec'
+  spec.add_development_dependency 'rspec-html-matchers'
 end

--- a/lib/xslt/iso2html.xsl
+++ b/lib/xslt/iso2html.xsl
@@ -1,1745 +1,1070 @@
-<!--
-From : https://raw.githubusercontent.com/geoblacklight/geoblacklight-schema/master/tools/iso2html/iso-html.xsl
-Modified by Darren Hardy, Stanford University Libraries, 2014
+<?xml version="1.0" encoding="utf-8" ?>
 
-pacioos-iso-html.xsl
+<!-- 
+     iso2html.xsl - Transformation from ISO 19139 into HTML 
+     Created by Kim Durante, Stanford University Libraries
+     
+     TODO: Needs full Data Quality section mapped
+           Not sure if complete contactInfo is needed for each Responsible Party? 
 
-Author: John Maurer (jmaurer@hawaii.edu)
-Date: November 1, 2011
-
-This Extensible Stylesheet Language for Transformations (XSLT) document takes
-metadata in Extensible Markup Language (XML) for the ISO 19115
-with Remote Sensing Extensions (RSE) and converts it into an HTML page. This 
-format is used to show the full metadata record on PacIOOS's website.
-
-For more information on XSLT see:
-
-http://en.wikipedia.org/wiki/XSLT
-http://www.w3.org/TR/xslt
-
--->
-
-<xsl:stylesheet
-  version="1.0"
-  xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xmlns:gco="http://www.isotc211.org/2005/gco"
-  xmlns:gmd="http://www.isotc211.org/2005/gmd"
-  xmlns:gmi="http://www.isotc211.org/2005/gmi"
-  xmlns:gmx="http://www.isotc211.org/2005/gmx"
-  xmlns:gsr="http://www.isotc211.org/2005/gsr"
-  xmlns:gss="http://www.isotc211.org/2005/gss"
-  xmlns:gts="http://www.isotc211.org/2005/gts"
-  xmlns:srv="http://www.isotc211.org/2005/srv"
-  xmlns:gml="http://www.opengis.net/gml"
-  xmlns:xlink="http://www.w3.org/1999/xlink"
-  xmlns:xs="http://www.w3.org/2001/XMLSchema">
-
-  <!-- Import another XSLT file for replacing newlines with HTML <br/>'s: -->
-
-  <xsl:import href="utils/replace-newlines.xsl"/>
-
-  <!-- Import another XSLT file for doing other string substitutions: -->
-
-  <xsl:import href="utils/replace-string.xsl"/>
-
-  <!-- Import another XSLT file for limiting the number of decimal places: -->
-
-  <xsl:import href="utils/strip-digits.xsl"/>
-
-  <!-- 
-
-  This HTML output method conforms to the following DOCTYPE statement:
-
-    <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-      "http://www.w3.org/TR/html4/loose.dtd">
-  -->
-
-  <xsl:output
-    method="html"
-    doctype-public="-//W3C//DTD HTML 4.01 Transitional//EN"
-    doctype-system="http://www.w3.org/TR/html4/loose.dtd"
-    encoding="ISO-8859-1"
-    indent="yes"/>
-
-  <!-- VARIABLES: ***********************************************************-->
-
-  <!-- The separator separates short names from long names. For example:
-       DMSP > Defense Meteorological Satellite Program -->
-
-  <xsl:variable name="separator">
-     <xsl:text disable-output-escaping="yes">&amp;nbsp;</xsl:text>
-  </xsl:variable>
-
-  <!-- Define a variable for creating a newline: -->
-
-  <xsl:variable name="newline">
-<xsl:text>
-</xsl:text>
-  </xsl:variable>
-
-  <!-- This variable is used to link to the other metadata views.
-       NOTE: TDS FMRC ID's appear like "wrf_hi/WRF_Hawaii_Regional_Atmospheric_Model_best.ncd";
-       to simplify the ID's, strip everything after "/":
-  -->
-
-  <xsl:variable name="datasetIdentifier">
-    <xsl:variable name="datasetIdentifierOriginal" select="gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:identifier/gmd:MD_Identifier/gmd:code/gco:CharacterString"/>
-    <xsl:choose>
-      <xsl:when test="contains( $datasetIdentifierOriginal, '/' )">
-        <xsl:value-of select="substring-before( $datasetIdentifierOriginal, '/' )"/>
-      </xsl:when>
-      <xsl:otherwise>
-       <xsl:value-of select="$datasetIdentifierOriginal"/>
-      </xsl:otherwise>
-    </xsl:choose>
-  </xsl:variable>
-  
-  <!-- Define a variable which creates a JavaScript array of the bounding box
-       of the Spatial_Domain/Bounding element in the ISO for use in the Google
-       Maps API, which is controlled by the loadGoogleMap function inside
-       the google_maps.ssi include file. NOTE: This function expects the
-       bounding box to be provided in a specific order: north, south, east,
-       west: -->
-
-  <xsl:variable name="bbox">    
-    <xsl:if test="gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:extent/gmd:EX_Extent/gmd:geographicElement/gmd:EX_GeographicBoundingBox/gmd:northBoundLatitude/gco:Decimal">
-      <xsl:text> [ </xsl:text>
-      <xsl:value-of select="gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:extent/gmd:EX_Extent/gmd:geographicElement/gmd:EX_GeographicBoundingBox/gmd:northBoundLatitude/gco:Decimal"/><xsl:text>, </xsl:text>
-      <xsl:value-of select="gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:extent/gmd:EX_Extent/gmd:geographicElement/gmd:EX_GeographicBoundingBox/gmd:southBoundLatitude/gco:Decimal"/><xsl:text>, </xsl:text>
-      <xsl:value-of select="gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:extent/gmd:EX_Extent/gmd:geographicElement/gmd:EX_GeographicBoundingBox/gmd:eastBoundLongitude/gco:Decimal"/><xsl:text>, </xsl:text>
-      <xsl:value-of select="gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:extent/gmd:EX_Extent/gmd:geographicElement/gmd:EX_GeographicBoundingBox/gmd:westBoundLongitude/gco:Decimal"/>
-      <xsl:text> ] </xsl:text>
-    </xsl:if>
-  </xsl:variable>
-
-  <!-- TOP-LEVEL: HTML ******************************************************-->
-
-  <!-- The top-level template; Define various features for the entire page and then
-       call the "gmd:MD_Metadata" template to fill in the remaining HTML: -->
-
-  <xsl:template match="/">
-    <html xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml"><xsl:value-of select="$newline"/>
-    <head><xsl:value-of select="$newline"/>
-    <title><xsl:value-of select="gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:title/gco:CharacterString"/></title><xsl:value-of select="$newline"/>
-    <xsl:comment>
-If you want to show polylines on a Google Map (like the rectangle used to
-outline the data set geographic coverage), you need to include the VML
-namespace in the html tag and the following CSS code in an XHTML compliant
-doctype to make everything work properly in IE:
-</xsl:comment><xsl:value-of select="$newline"/>
-    <style type="text/css">
-
-  v\:* {
-    behavior:url(#default#VML);
-  }
-
-  .wrapline {
-    /* http://perishablepress.com/press/2010/06/01/wrapping-content/ */
-    white-space: pre;           /* CSS 2.0 */
-    white-space: pre-wrap;      /* CSS 2.1 */
-    white-space: pre-line;      /* CSS 3.0 */
-    white-space: -pre-wrap;     /* Opera 4-6 */
-    white-space: -o-pre-wrap;   /* Opera 7 */
-    white-space: -moz-pre-wrap; /* Mozilla */
-    white-space: -hp-pre-wrap;  /* HP Printers */
-    word-wrap: break-word;
-    width: 550px; 
-  }
-
-</style><xsl:value-of select="$newline"/>
-    </head><xsl:value-of select="$newline"/>
-    <body><xsl:value-of select="$newline"/>
-    <table width="99%" border="0" cellspacing="2" cellpadding="0">
-      <tr>
-        <td valign="top">
-          <table width="98%" border="0" align="center" cellpadding="2" cellspacing="8" style="margin-top: -20px;">
-            <tr>
-              <td valign="top" >
-                <!--<p style="color: darkred; background-color: lightyellow; border: 1px dashed lightgray; padding: 2px;"><b>NOTE: ISO metadata output is under construction. Please check back later...</b></p>-->
-                <h2 style="margin-right: 185px; text-transform: none;"><xsl:value-of select="gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:title/gco:CharacterString"/></h2>
+     
+     
+     -->
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    xmlns:gmd="http://www.isotc211.org/2005/gmd" 
+    xmlns:gco="http://www.isotc211.org/2005/gco" 
+    xmlns:gts="http://www.isotc211.org/2005/gts" 
+    xmlns:srv="http://www.isotc211.org/2005/srv" 
+    xmlns:gml="http://www.opengis.net/gml"
+    exclude-result-prefixes="gmd gco gml srv xlink gts">
+    
+    <xsl:output method="html" encoding="UTF-8" indent="yes"/>
+    
+    <xsl:template match="/">
+        <html>
+            <head>
+                <title><xsl:value-of select="gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:title"/></title>
+            </head>
+            <body>
+                <h1><xsl:value-of select="gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:title"/></h1>
                 <ul>
-                  <li><a href="#Identification_Information">Identification Information</a></li>
-                  <xsl:if test="string-length( gmd:MD_Metadata/gmd:dataQualityInfo )">
-                    <li><a href="#Data_Quality_Information">Data Quality Information</a></li>
-                  </xsl:if>
-                  <xsl:if test="string-length( gmd:MD_Metadata/gmd:spatialRepresentationInfo )">
-                    <li><a href="#Spatial_Representation_Information">Spatial Representation Information</a></li>
-                  </xsl:if>
-                  <xsl:if test="string-length( gmd:MD_Metadata/gmd:contentInfo )">
-                    <li><a href="#Content_Information">Content Information</a></li>
-                  </xsl:if>
-                  <xsl:if test="string-length( gmd:MD_Metadata/gmd:distributionInfo )">
-                    <li><a href="#Distribution_Information">Distribution Information</a></li>                  
-                  </xsl:if>
-                  <xsl:if test="string-length( gmd:MD_Metadata/gmd:acquisitionInformation )">
-				            <li><a href="#Acquisition_Information">Acquisition Information</a></li>
-                  </xsl:if>
-                  <li><a href="#Metadata_Reference_Information">Metadata Reference Information</a></li>
+               <xsl:if test="gmd:MD_Metadata/gmd:identificationInfo">
+                    <li><a href="#iso-identification-info">Identification Information</a></li>
+                </xsl:if>
+                    
+                <xsl:if test="gmd:MD_Metadata/gmd:referenceSystemInfo">
+                    <li><a href="#iso-spatial-reference-info">Spatial Reference Information</a></li>
+                </xsl:if>
+
+                <xsl:if test="gmd:MD_Metadata/gmd:dataQualityInfo">
+                    <li><a href="#iso-data-quality-info">Data Quality Information</a></li>
+                </xsl:if>
+
+                <xsl:if test="gmd:MD_Metadata/gmd:distributionInfo">
+                    <li><a href="#iso-distribution-info">Distribution Information</a></li>
+                </xsl:if>
+
+                <xsl:if test="gmd:MD_Metadata/gmd:contentInfo">
+                    <li><a href="#iso-content-info">Content Information</a></li>
+                </xsl:if>
+                
+                <xsl:if test="gmd:MD_Metadata/gmd:spatialRepresentationInfo">
+                    <li><a href="#iso-spatial-representation-info">Spatial Representation Information</a></li>
+                </xsl:if>
+                
+                <xsl:if test="gmd:MD_Metadata">
+                    <li><a href="#iso-metadata-reference-info">Metadata Reference Information</a></li>
+                </xsl:if>
                 </ul>
-                <xsl:apply-templates select="gmd:MD_Metadata"/>
-              </td>
-            </tr>
-          </table>
-        </td>
-      </tr>
-    </table>
-    <xsl:comment> END MAIN CONTENT </xsl:comment><xsl:value-of select="$newline"/>
-  </body><xsl:value-of select="$newline"/>
-    </html>
-  </xsl:template>
+                <xsl:apply-templates/>
+            </body>
+        </html>
+    </xsl:template>
+    
 
-  <!-- The second-level template: match all the main elements of the ISO and
-       process them separately. The order of these elements is maintained in
-       the resulting document: -->
+    <xsl:template match="gmd:MD_Metadata">
+      <div id="iso-identification-info">
+        <dl>
+          <dt>Identification Information</dt>
+          <dd>
+                <dl>
+                  <xsl:for-each select="gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation">
+                      <dt>Citation</dt>
+                      <dd>
+                          <dl>
+                             <dt>Title</dt>
+                                <dd>
+                                   <xsl:value-of select="gmd:title"/>
+                                </dd>
+                              <xsl:choose>
+                                  <xsl:when test="gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:role/gmd:CI_RoleCode[@codeListValue='originator']">
+                                      <xsl:for-each select="gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:role/gmd:CI_RoleCode[@codeListValue='originator']">
+                                      <dt>Originator</dt>
+                                      <dd><xsl:value-of select="ancestor-or-self::*/gmd:organisationName | ancestor-or-self::*/gmd:individualName"/></dd>
+                                      </xsl:for-each>
+                                      </xsl:when>
+                                  
+                                  <xsl:when test="//gmd:identificationInfo/gmd:MD_DataIdentification/gmd:pointOfContact">
+                                  <xsl:for-each select="//gmd:identificationInfo/gmd:MD_DataIdentification/gmd:pointOfContact">
+                                  <xsl:if test="gmd:CI_ResponsibleParty/gmd:role/gmd:CI_RoleCode/@codeListValue='originator'">
+                                  <dt>Originator</dt>
+                                  <dd><xsl:value-of select="gmd:CI_ResponsibleParty/gmd:organisationName | gmd:CI_ResponsibleParty/gmd:individualName"/></dd>
+                                  </xsl:if>
+                              </xsl:for-each>
+                                  </xsl:when>
+                              </xsl:choose>
+                             
+                              <xsl:for-each select="gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:role/gmd:CI_RoleCode[@codeListValue='publisher']">
+                                  <dt>Publisher</dt>
+                                  <dd><xsl:value-of select="ancestor-or-self::*/gmd:organisationName | ancestor-or-self::*/gmd:individualName"/></dd>
+                                  <xsl:if test="ancestor-or-self::*/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:city">
+                                  <dt>Place of Publication</dt>   
+                                  <dd><xsl:value-of select="ancestor-or-self::*/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:city"/>
+                                      <xsl:if test="ancestor-or-self::*/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:administrativeArea">
+                                          <xsl:text>,</xsl:text>
+                                          <xsl:value-of select="ancestor-or-self::*/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:administrativeArea"/>
+                                      </xsl:if>
+                                      <xsl:if test="ancestor-or-self::*/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:country">
+                                          <xsl:text>,</xsl:text>
+                                          <xsl:value-of select="ancestor-or-self::*/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:country"/>
+                                      </xsl:if>
+                                  </dd>    
+                                  </xsl:if>
+                              </xsl:for-each>
+                              
+                              
 
-  <!-- ROOT: ****************************************************************-->
-
-  <xsl:template match="gmd:MD_Metadata">
-    <xsl:apply-templates select="gmd:identificationInfo/gmd:MD_DataIdentification"/>
-    <xsl:if test="string-length( gmd:identificationInfo/srv:SV_ServiceIdentification )">
-      <h4>Services:</h4>
-    </xsl:if>
-    <xsl:apply-templates select="gmd:identificationInfo/srv:SV_ServiceIdentification"/>
-    <p><a href="javascript:void(0)" onClick="window.scrollTo( 0, 0 ); this.blur(); return false;">Back to Top</a></p>
-    <xsl:apply-templates select="gmd:dataQualityInfo/gmd:DQ_DataQuality"/>
-    <xsl:apply-templates select="gmd:spatialRepresentationInfo/gmd:MD_GridSpatialRepresentation"/>
-    <xsl:apply-templates select="gmd:contentInfo"/>
-    <xsl:apply-templates select="gmd:distributionInfo/gmd:MD_Distribution"/>
-    <xsl:apply-templates select="gmd:acquisitionInformation/gmd:MI_AcquisitionInformation"/>
-    <xsl:call-template name="metadataReferenceInfo"/>
-  </xsl:template>
-
-  <!-- METADATA_REFERENCE_INFORMATION: *****************************************
-
-  NOTE: I have combined the following sections under this heading:
-
-      1. METADATA_ENTITY_SET_INFORMATION (miscellaneous stuff under root doc)
-      2. METADATA_MAINTENANCE_INFORMATION (I stuck this within the above)
-      3. METADATA_EXTENSION_INFORMATION (ditto)
-  --> 
-
-  <xsl:template name="metadataReferenceInfo">
-    <hr/>
-    <h3><a name="Metadata_Reference_Information"></a>Metadata Reference Information:</h3>
-    <xsl:call-template name="metadataEntitySetInfo"/>
-    <p><a href="javascript:void(0)" onClick="window.scrollTo( 0, 0 ); this.blur(); return false;">Back to Top</a></p>
-  </xsl:template>
- 
-  <!-- METADATA_ENTITY_SET_INFORMATION: ************************************--> 
-
-  <xsl:template name="metadataEntitySetInfo">
-    <xsl:apply-templates select="gmd:fileIdentifier"/>
-    <xsl:apply-templates select="gmd:language"/>
-    <xsl:apply-templates select="gmd:characterSet"/>
-    <xsl:apply-templates select="gmd:parentIdentifier"/>
-    <xsl:apply-templates select="gmd:hierarchyLevel"/>
-    <xsl:apply-templates select="gmd:hierarchyLevelName"/>
-    <xsl:apply-templates select="gmd:contact"/>
-    <xsl:apply-templates select="gmd:dateStamp"/>
-    <xsl:apply-templates select="gmd:metadataMaintenance/gmd:MD_MaintenanceInformation"/>
-    <xsl:apply-templates select="gmd:metadataExtensionInfo/gmd:MD_MetadataExtensionInformation"/>
-    <xsl:apply-templates select="gmd:metadataStandardName"/>
-    <xsl:apply-templates select="gmd:metadataStandardVersion"/>
-    <xsl:apply-templates select="gmd:dataSetURI"/>
-  </xsl:template>
-
- <xsl:template match="gmd:fileIdentifier">
-    <h4 style="display: inline">File Identifier: </h4>
-    <xsl:variable name="fileURL">
-         <xsl:value-of select="gco:CharacterString"/>
-        </xsl:variable>
-    <xsl:value-of select="$fileURL"/>
-  <!--  <p style="display: inline"><a href="{$fileURL}"><xsl:value-of select="$fileURL"/></a></p>  -->
-    <p></p>
-  </xsl:template>
-
-  <xsl:template match="gmd:language">
-    <h4 style="display: inline">Language:</h4>
-    <p style="display: inline"><xsl:value-of select="."/></p>
-    <p></p>
-  </xsl:template>
-
-  <xsl:template match="gmd:parentIdentifier">
-    <h4 style="display: inline">Parent Identifier:</h4>
-    <xsl:variable name="parentURL">
-      <xsl:value-of select="gco:CharacterString"/>
-    </xsl:variable>
-    <p style="display: inline"><a href="{$parentURL}"><xsl:value-of select="."/></a></p>
-    <p></p>
-  </xsl:template>
-
-  <xsl:template match="gmd:characterSet">
-    <h4 style="display: inline">Character Set:</h4>
-    <p style="display: inline"><xsl:value-of select="."/> (<a href="http://pacioos.org/metadata/gmxCodelists.html#MD_CharacterSetCode" target="_blank">MD_CharacterSetCode</a>)</p>
-    <p></p>
-  </xsl:template>
-
-  <xsl:template match="gmd:hierarchyLevel">
-    <h4 style="display: inline">Hierarchy Level:</h4>
-    <p style="display: inline"><xsl:value-of select="."/> (<a href="http://pacioos.org/metadata/gmxCodelists.html#MD_ScopeCode" target="_blank">MD_ScopeCode</a>)</p>
-    <p></p>
-  </xsl:template>
-
-  <xsl:template match="gmd:hierarchyLevelName">
-    <h4 style="display: inline">Hierarchy Level Name:</h4>
-    <p style="display: inline"><xsl:value-of select="."/></p>
-    <p></p>
-  </xsl:template>
-  
-  <xsl:template match="gmd:contact">
-    <h4>Contact:</h4>
-    <xsl:call-template name="CI_ResponsibleParty">
-      <xsl:with-param name="element" select="gmd:CI_ResponsibleParty"/>
-      <xsl:with-param name="italicize-heading" select="true()"/>      
-    </xsl:call-template>        
-  </xsl:template>
-  
-  <xsl:template match="gmd:dateStamp">
-    <h4 style="display: inline">Date Stamp:</h4>
-    <p style="display: inline">
-      <xsl:call-template name="date">
-        <xsl:with-param name="element" select="./gco:Date"/>
-      </xsl:call-template>
-    </p>
-    <p></p>
-  </xsl:template>
-
-  <xsl:template match="gmd:metadataStandardName">
-    <h4>Metadata Standard Name:</h4>
-    <p><xsl:value-of select="."/></p>
-  </xsl:template>
-
-  <xsl:template match="gmd:metadataStandardVersion">
-    <h4>Metadata Standard Version:</h4>
-    <p><xsl:value-of select="."/></p>
-  </xsl:template>
-
-  <xsl:template match="gmd:dataSetURI">
-    <h4>Dataset URI:</h4>
-    <p><a href="{.}"><xsl:value-of select="."/></a></p>
-  </xsl:template>
-
-  <!-- METADATA_MAINTENANCE_INFORMATION: ************************************-->
-
-  <xsl:template match="gmd:metadataMaintenance/gmd:MD_MaintenanceInformation">
-    <h4>Metadata Maintenance Information:</h4>
-    <xsl:apply-templates select="gmd:maintenanceAndUpdateFrequency"/>
-    <xsl:apply-templates select="gmd:maintenanceNote"/>
-    <!--
-    Duplicates gmd:contact above so ignore here...
-    <xsl:apply-templates select="gmd:contact"/>
-    -->
-  </xsl:template>
-
-  <xsl:template match="gmd:maintenanceAndUpdateFrequency">
-    <p>
-      <b><i>Maintenance And Update Frequency: </i></b>
-      <xsl:choose>
-        <xsl:when test="string-length( . )">
-          <xsl:value-of select="."/> 
-        </xsl:when>
-        <xsl:otherwise>
-          <xsl:value-of select="@gco:nilReason"/>
-        </xsl:otherwise>
-      </xsl:choose>
-    </p>
-  </xsl:template>
-
-  <xsl:template match="gmd:maintenanceNote">
-    <xsl:if test="string-length( . )">
-      <p><b><i>Maintenance Note:</i></b></p>
-      <p><xsl:value-of select="."/></p>
-    </xsl:if>
-  </xsl:template>
-
-  <!-- METADATA_EXTENSION_INFORMATION: **************************************-->
-
-  <xsl:template match="gmd:metadataExtensionInfo/gmd:MD_MetadataExtensionInformation">
-    <h4>Metadata Extension Information:</h4>
-    <xsl:for-each select="gmd:extendedElementInformation/gmd:MD_ExtendedElementInformation">
-      <p><b><i>Extended Element Information:</i></b></p>
-      <font>
-      <blockquote>
-        <xsl:for-each select="gmd:name">
-          <xsl:if test="string-length( . )">
-            <b>Name: </b> <xsl:value-of select="."/><br/>
-          </xsl:if>
-        </xsl:for-each> 
-        <xsl:for-each select="gmd:shortName">
-          <xsl:if test="string-length( . )">
-            <b>Short Name: </b> <xsl:value-of select="."/><br/>
-          </xsl:if>
-        </xsl:for-each> 
-        <xsl:for-each select="gmd:obligation">
-          <xsl:if test="string-length( gmd:MD_ObligationCode )">
-            <b>Obligation: </b><xsl:value-of select="gmd:MD_ObligationCode"/> (<a href="http://pacioos.org/metadata/gmxCodelists.html#MD_ObligationCode">MD_ObligationCode</a>)<br/>
-          </xsl:if>
-        </xsl:for-each>
-        <xsl:for-each select="gmd:dataType">
-          <xsl:if test="string-length( gmd:MD_DatatypeCode )">
-            <b>Data Type: </b><xsl:value-of select="gmd:MD_DatatypeCode"/> (<a href="http://pacioos.org/metadata/gmxCodelists.html#MD_DatatypeCode">MD_DatatypeCode</a>)<br/>
-          </xsl:if>
-        </xsl:for-each>
-        <xsl:for-each select="gmd:maximumOccurrence">
-          <xsl:if test="string-length( . )">
-            <b>Maximum Occurrence: </b> <xsl:value-of select="."/><br/>
-          </xsl:if>
-        </xsl:for-each>
-        <xsl:for-each select="gmd:parentEntity">
-          <xsl:if test="string-length( . )">
-            <b>Parent Entity: </b> <xsl:value-of select="."/><br/>
-          </xsl:if>
-        </xsl:for-each>
-        <xsl:for-each select="gmd:rule">
-          <xsl:if test="string-length( . )">
-            <b>Rule: </b><br/>
-            <p><xsl:value-of select="."/></p>
-          </xsl:if>
-        </xsl:for-each>
-        <xsl:for-each select="gmd:definition">
-          <xsl:if test="string-length( . )">
-            <p><b>Definition:</b></p>
-            <p><xsl:value-of select="."/></p>
-          </xsl:if>
-        </xsl:for-each>
-        <xsl:for-each select="gmd:rationale">
-          <xsl:if test="string-length( . )">
-            <p><b>Rationale:</b></p>
-            <p><xsl:value-of select="."/></p>
-          </xsl:if>
-        </xsl:for-each>
-        <xsl:for-each select="gmd:source">
-          <xsl:if test="string-length( . )">
-            <p><b>Source:</b></p>
-            <blockquote>
-              <xsl:call-template name="CI_ResponsibleParty">
-                <xsl:with-param name="element" select="gmd:CI_ResponsibleParty"/>
-              </xsl:call-template>
-            </blockquote>
-          </xsl:if>
-        </xsl:for-each>
-      </blockquote>
-      </font>
-    </xsl:for-each>
-  </xsl:template>
- 
-  <!-- IDENTIFICATION_INFORMATION: ******************************************-->
- 
-  <xsl:template match="gmd:identificationInfo/gmd:MD_DataIdentification">
-    <hr/>
-    <h3><a name="Identification_Information"></a> Identification Information:</h3>
-    <xsl:apply-templates select="gmd:citation"/>
-    <xsl:apply-templates select="gmd:abstract"/>
-    <xsl:apply-templates select="gmd:purpose"/>
-    <xsl:apply-templates select="gmd:credit"/>
-    <xsl:apply-templates select="gmd:status"/>
-    <xsl:apply-templates select="gmd:pointOfContact"/>
-    <xsl:apply-templates select="gmd:resourceMaintenance"/>
-    <xsl:apply-templates select="gmd:graphicOverview"/>
-    <xsl:if test="gmd:descriptiveKeywords">
-      <h4>Descriptive Keywords:</h4>
-      <xsl:apply-templates select="gmd:descriptiveKeywords"/>
-    </xsl:if>
-    <xsl:apply-templates select="gmd:taxonomy"/>
-    <xsl:apply-templates select="gmd:aggregationInfo"/>
-    <xsl:apply-templates select="gmd:resourceConstraints"/>
-    <xsl:apply-templates select="gmd:language"/>
-    <xsl:apply-templates select="gmd:characterSet"/>
-    <xsl:if test="gmd:topicCategory">
-      <h4>Topic Categories (<a href="http://pacioos.org/metadata/gmxCodelists.html#MD_TopicCategoryCode">MD_TopicCategoryCode</a>):</h4>
-      <blockquote>
-        <font>
-        <xsl:for-each select="gmd:topicCategory">
-          <xsl:sort select="."/>
-          <b>Topic Category: </b><xsl:value-of select="."/><br/>
-        </xsl:for-each>
-        </font>
-      </blockquote>
-    </xsl:if>
-    <xsl:apply-templates select="gmd:extent"/>
-    <xsl:apply-templates select="gmd:supplementalInformation"/>
-  </xsl:template>
-
-  <xsl:template match="gmd:citation">
-    <h4>Citation:</h4>
-    <font>
-    <xsl:call-template name="CI_Citation">
-      <xsl:with-param name="element" select="gmd:CI_Citation"/>
-      <xsl:with-param name="italicize-heading" select="true()"/>
-      <xsl:with-param name="wrap-text" select="true()"/>
-    </xsl:call-template>
-    </font>
-  </xsl:template>
-
-  <xsl:template match="gmd:abstract">
-    <h4>Abstract:</h4>
-    <p>
-      <xsl:call-template name="replace-newlines">
-        <xsl:with-param name="element" select="gco:CharacterString"/>
-      </xsl:call-template>
-    </p>
-  </xsl:template>
-
-  <xsl:template match="gmd:purpose">
-    <h4>Purpose:</h4>
-    <p><xsl:value-of select="."/></p>
-  </xsl:template>
-
-  <xsl:template match="gmd:credit">
-    <h4>Credit:</h4>
-    <p><xsl:value-of select="."/></p>
-  </xsl:template>
-
-  <xsl:template match="gmd:status">
-    <h4 style="display: inline">Status:</h4>
-    <p style="display: inline"><xsl:value-of select="."/> (<a href="http://pacioos.org/metadata/gmxCodelists.html#MD_ProgressCode" target="_blank">MD_ProgressCode</a>)</p>
-    <p></p>
-  </xsl:template>
-
-  <xsl:template match="gmd:pointOfContact">
-    <h4>Point of Contact:</h4>
-    <xsl:for-each select="gmd:CI_ResponsibleParty">        
-      <xsl:call-template name="CI_ResponsibleParty">
-        <xsl:with-param name="element" select="."/>
-        <xsl:with-param name="italicize-heading" select="true()"/>
-      </xsl:call-template>        
-    </xsl:for-each>      
-  </xsl:template>
-
-  <xsl:template match="gmd:resourceMaintenance">
-    <h4>Maintenance Information:</h4>
-    <xsl:for-each select="gmd:MD_MaintenanceInformation">
-      <xsl:for-each select="gmd:maintenanceAndUpdateFrequency">
-        <p><b><i>Maintenance and Update Frequency: </i></b> <xsl:value-of select="."/> (<a href="http://pacioos.org/metadata/gmxCodelists.html#MD_MaintenanceFrequencyCode">MD_MaintenanceFrequencyCode</a>)</p>
-      </xsl:for-each>
-      <xsl:for-each select="gmd:updateScope">
-        <p><b><i>Update Scope:</i></b> <xsl:value-of select="."/> (<a href="http://pacioos.org/metadata/gmxCodelists.html#MD_ScopeCode">MD_ScopeCode</a>)</p>
-      </xsl:for-each>
-      <xsl:for-each select="gmd:contact">
-        <p><b><i>Contact:</i></b></p>
-        <xsl:call-template name="CI_ResponsibleParty">
-          <xsl:with-param name="element" select="gmd:CI_ResponsibleParty"/>
-          <xsl:with-param name="italicize-heading" select="false()"/>
-        </xsl:call-template>
-      </xsl:for-each>
-    </xsl:for-each>
-  </xsl:template>
-
-  <xsl:template match="gmd:graphicOverview">
-    <h4>Browse Graphic:</h4>    
-    <xsl:for-each select="gmd:MD_BrowseGraphic">
-      <xsl:for-each select="gmd:fileName">
-        <p>
-          <!--<a href="{.}" target="_blank"><img src="{.}" height="260" border="0"/></a><br/>-->
-          <a href="{.}" class="browse fancybox fancybox.image"><img src="{.}" height="400" border="0"/></a><br/>
-          <a href="{.}" class="browse fancybox fancybox.image">View full image</a>
-        </p>
-        <p><b><i>Image File: </i></b><a href="{.}"><xsl:value-of select="."/></a></p>
-      </xsl:for-each>
-      <xsl:for-each select="gmd:fileDescription">
-        <p><b><i>File Description:</i></b></p>
-        <p><xsl:value-of select="."/></p>
-      </xsl:for-each>
-      <xsl:for-each select="gmd:fileType">
-        <p><b><i>File Type: </i></b><xsl:value-of select="."/></p>
-      </xsl:for-each>
-    </xsl:for-each>
-  </xsl:template>
-
-  <!--Create keywords indices (keys) so that we can do a unique sort below: -->
-
-  <xsl:key name="values_by_id" match="gmd:keyword" use="gco:CharacterString"/>
-
-  <xsl:template match="gmd:descriptiveKeywords">
-    <font>
-    <xsl:for-each select="gmd:MD_Keywords">        
-      <p><b><i>Keywords:</i></b></p>
-      <blockquote>
-        <xsl:for-each select="gmd:type">
-          <p><b>Keyword Type: </b><xsl:value-of select="."/> (<a href="http://pacioos.org/metadata/gmxCodelists.html#MD_KeywordTypeCode">MD_KeywordTypeCode</a>)</p>
-        </xsl:for-each>
-        <!--
-        Do unique sort method below instead to remove duplicates...
-        <xsl:for-each select="gmd:keyword">
-          <xsl:sort select="."/>
-          <b>Keyword: </b><xsl:value-of select="."/><br/>
-        </xsl:for-each>
-        -->
-        <!--
-        But this sort is excluding keywords from different groups that match;
-        e.g. when Project and Data Center are both the same...
-        <xsl:for-each select="gmd:keyword[ count( . | key( 'values_by_id', translate( normalize-space( gco:CharacterString ), ',', '' ) )[ 1 ]) = 1 ]">
-        -->
-        <xsl:for-each select="gmd:keyword">
-          <xsl:sort select="gco:CharacterString"/>
-          <xsl:if test="gco:CharacterString != '&gt;'">
-            <xsl:variable name="keyword">
-              <xsl:call-template name="replace-string">
-                <xsl:with-param name="element" select="gco:CharacterString"/>
-                <xsl:with-param name="old-string">&gt;</xsl:with-param>
-                <xsl:with-param name="new-string"><xsl:value-of select="$separator"/></xsl:with-param>
-              </xsl:call-template>
-            </xsl:variable>
-            <xsl:variable name="keyword2">
-              <xsl:call-template name="replace-string">
-                <xsl:with-param name="element" select="$keyword"/>
-                <xsl:with-param name="old-string">&amp;gt;</xsl:with-param>
-                <xsl:with-param name="new-string"><xsl:value-of select="$separator"/></xsl:with-param>
-              </xsl:call-template>
-            </xsl:variable>
-            <b>Keyword: </b><xsl:value-of select="$keyword2" disable-output-escaping="yes"/><br/>
-          </xsl:if>
-        </xsl:for-each>
-        <xsl:for-each select="gmd:thesaurusName">
-          <xsl:choose>
-            <xsl:when test="string-length( . )">
-              <p><b>Keyword Thesaurus:</b></p>
-              <blockquote>
-              <xsl:for-each select="gmd:CI_Citation">
-                <xsl:call-template name="CI_Citation">
-                  <xsl:with-param name="element" select="."/>
-                  <xsl:with-param name="italicize-heading" select="false()"/>
-                </xsl:call-template>
-              </xsl:for-each>
-              </blockquote>
-            </xsl:when>
-            <xsl:otherwise>
-              <p><b>Keyword Thesaurus: </b><xsl:value-of select="@gco:nilReason"/></p>
-            </xsl:otherwise>
-          </xsl:choose>
-        </xsl:for-each>
-      </blockquote>
-    </xsl:for-each>    
-    </font>
-  </xsl:template>
-
-  <xsl:template match="gmd:taxonomy">
-    <h4>Taxonomy:</h4>
-    <font>
-    <xsl:for-each select="gmd:MD_TaxonSys">
-      <p><b><i>Taxonomic System:</i></b></p>
-      <blockquote>
-        <xsl:for-each select="gmd:classSys">
-          <xsl:call-template name="CI_Citation">
-            <xsl:with-param name="element" select="gmd:CI_Citation"/>
-          </xsl:call-template>
-        </xsl:for-each>
-        <xsl:for-each select="gmd:idref">
-          <xsl:for-each select="gmd:RS_Identifier">
-            <p><b>Identification Reference:</b></p>
-            <xsl:for-each select="gmd:authority">
-              <blockquote>
-                <xsl:call-template name="CI_Citation">
-                  <xsl:with-param name="element" select="gmd:CI_Citation"/>
-                </xsl:call-template>
-              </blockquote>
-            </xsl:for-each>
-          </xsl:for-each>
-        </xsl:for-each>
-        <xsl:for-each select="gmd:obs">
-          <p><b>Observer:</b></p>
-          <blockquote>
-            <xsl:call-template name="CI_ResponsibleParty">
-              <xsl:with-param name="element" select="gmd:CI_ResponsibleParty"/>
-            </xsl:call-template> 
-          </blockquote>
-        </xsl:for-each>
-        <xsl:for-each select="gmd:taxonpro">
-          <p><b>Taxonomic Procedures:</b></p>
-          <p><xsl:value-of select="."/></p> 
-        </xsl:for-each>
-        <xsl:for-each select="gmd:taxoncom">
-          <p><b>Taxonomic Completeness:</b></p>
-          <p><xsl:value-of select="."/></p>
-        </xsl:for-each>
-        <xsl:for-each select="gmd:taxonCl">
-          <p><b>Taxonomic Classification:</b></p>
-          <xsl:apply-templates select="./gmd:MD_TaxonCl" />
-        </xsl:for-each>
-      </blockquote>
-    </xsl:for-each>
-    </font>
-  </xsl:template>
-
-  <xsl:template match="gmd:aggregationInfo">
-    <h4>Aggregation Information:</h4>
-    <xsl:for-each select="gmd:MD_AggregateInformation/gmd:aggregateDataSetName">
-      <p><b><i>Aggregate Dataset Name:</i></b></p>
-      <font>
-      <blockquote>
-        <xsl:call-template name="CI_Citation">
-          <xsl:with-param name="element" select="gmd:CI_Citation"/>
-        </xsl:call-template>
-      </blockquote>
-      </font>
-    </xsl:for-each>
-    <xsl:for-each select="gmd:MD_AggregateInformation/gmd:aggregateDataSetIdentifier">
-      <p><b><i>Aggregate Dataset Identifier:</i></b></p>
-      <font>
-      <blockquote>
-        <xsl:if test="gmd:MD_Identifier/gmd:code">
-          <b>Code: </b><xsl:value-of select="gmd:MD_Identifier/gmd:code"/><br/>
-        </xsl:if>
-        <xsl:if test="gmd:MD_Identifier/gmd:authority">
-          <b>Authority: </b><xsl:value-of select="gmd:MD_Identifier/gmd:authority/gmd:CI_Citation/gmd:title"/><br/>
-        </xsl:if>
-      </blockquote>
-      </font>
-    </xsl:for-each>
-    <xsl:for-each select="gmd:MD_AggregateInformation/gmd:associationType">
-      <p><b><i>Association Type: </i></b> <xsl:value-of select="gmd:DS_AssociationTypeCode"/> (<a href="http://pacioos.org/metadata/gmxCodelists.html#DS_AssociationTypeCode">DS_AssociationTypeCode</a>)</p>
-    </xsl:for-each>
-    <xsl:for-each select="gmd:MD_AggregateInformation/gmd:initiativeType">
-      <p><b><i>Initiative Type: </i></b> <xsl:value-of select="gmd:DS_InitiativeTypeCode"/> (<a href="http://pacioos.org/metadata/gmxCodelists.html#DS_InitiativeTypeCode">DS_InitiativeTypeCode</a>)</p> 
-    </xsl:for-each>
-  </xsl:template>
-
-  <xsl:template match="gmd:resourceConstraints">
-    <h4>Resource Constraints:</h4>
-    <xsl:for-each select="gmd:MD_LegalConstraints">
-      <p><b><i>Legal Constraints:</i></b></p>
-      <blockquote>
-        <xsl:for-each select="gmd:accessConstraints">
-          <p><b>Access Constraints: </b><xsl:value-of select="."/> (<a href="http://pacioos.org/metadata/gmxCodelists.html#MD_RestrictionCode">MD_RestrictionCode</a>)</p>
-        </xsl:for-each>
-        <xsl:for-each select="gmd:useConstraints">
-          <p><b>Use Constraints: </b><xsl:value-of select="."/> (<a href="http://pacioos.org/metadata/gmxCodelists.html#MD_RestrictionCode">MD_RestrictionCode</a>)</p>
-        </xsl:for-each>
-        <xsl:for-each select="gmd:otherConstraints">
-          <p><b>Other Constraints:</b></p>
-          <p><xsl:value-of select="."/></p>
-        </xsl:for-each>
-        <xsl:for-each select="gmd:useLimitation">
-          <p><b>Use Limitation:</b></p>
-          <p><xsl:value-of select="."/></p> 
-        </xsl:for-each>
-      </blockquote>
-    </xsl:for-each>
-  </xsl:template>
-
-  <xsl:template match="gmd:extent">
-    <h4>Extent Information:</h4>
-    <font>
-    <xsl:for-each select="gmd:EX_Extent">
-      <p><b><i>Spatial Temporal Extent:</i></b></p>
-      <blockquote>
-      <xsl:for-each select="gmd:geographicElement">
-        <p><b>Geographic Element:</b></p>
-        <blockquote>          
-          <p><b>Bounding Coordinates:</b></p>
-          <blockquote>
-            <xsl:comment> Area to display current cursor lat/lon location: </xsl:comment>
-            <div id="message" class="SmallTextGray">&#160;</div>
-            <b>Westbound Longitude: </b>
-            <xsl:call-template name="strip-digits">
-              <xsl:with-param name="element" select="gmd:EX_GeographicBoundingBox/gmd:westBoundLongitude/gco:Decimal"/>
-              <xsl:with-param name="num-digits" select="5"/>
-            </xsl:call-template>&#176;<br/>
-            <b>Eastbound Longitude: </b>
-            <xsl:call-template name="strip-digits">
-              <xsl:with-param name="element" select="gmd:EX_GeographicBoundingBox/gmd:eastBoundLongitude/gco:Decimal"/>
-              <xsl:with-param name="num-digits" select="5"/>
-            </xsl:call-template>&#176;<br/>
-            <b>Southbound Latitude: </b>
-            <xsl:call-template name="strip-digits">
-              <xsl:with-param name="element" select="gmd:EX_GeographicBoundingBox/gmd:southBoundLatitude/gco:Decimal"/>
-              <xsl:with-param name="num-digits" select="5"/>
-            </xsl:call-template>&#176;<br/>
-            <b>Northbound Latitude: </b>
-            <xsl:call-template name="strip-digits">
-              <xsl:with-param name="element" select="gmd:EX_GeographicBoundingBox/gmd:northBoundLatitude/gco:Decimal"/>
-              <xsl:with-param name="num-digits" select="5"/>
-            </xsl:call-template>&#176;<br/>
-          </blockquote>        
-        </blockquote>
-      </xsl:for-each>
-    <xsl:for-each select="gmd:temporalElement">
-          <p><b>Temporal Element:</b></p>
-          <blockquote>
-            <p><b>Time Period:</b></p>
-            <blockquote>
-              <xsl:for-each select="//gmd:identificationInfo/gmd:MD_DataIdentification/gmd:extent/gmd:EX_Extent/gmd:description">
-                <b>Description: </b><xsl:value-of select="."/><br/>
-              </xsl:for-each>
-              <xsl:choose>
-                <xsl:when test="gmd:EX_TemporalExtent/gmd:extent/gml:TimePeriod/gml:beginPosition">
-              <xsl:for-each select="gmd:EX_TemporalExtent/gmd:extent/gml:TimePeriod/gml:beginPosition">
-                <b>Begin Position: </b>
-                <xsl:call-template name="date">
-                  <xsl:with-param name="element" select="."/>
-                </xsl:call-template>
-                <br/>
-              </xsl:for-each>
-              <xsl:for-each select="gmd:EX_TemporalExtent/gmd:extent/gml:TimePeriod/gml:endPosition">
-                <b>End Position: </b>
-                <xsl:call-template name="date">
-                  <xsl:with-param name="element" select="."/>
-                </xsl:call-template>
-                <br/>
-              </xsl:for-each>
-                </xsl:when>
-                <xsl:when test="gmd:EX_TemporalExtent/gmd:extent/gml:TimeInstant/gml:timePosition">
-                  <xsl:for-each select="gmd:EX_TemporalExtent/gmd:extent/gml:TimeInstant/gml:timePosition">
-                    <b>Time Instant: </b>
-                  <xsl:call-template name="date">
-                    <xsl:with-param name="element" select="."/>
-                  </xsl:call-template>
-                    <br/>
+                               <xsl:for-each select="gmd:date/gmd:CI_Date">
+                                   <xsl:if test="contains(gmd:dateType/gmd:CI_DateTypeCode/@codeListValue,'publication')">
+                                    <dt>Publication Date</dt>
+                                       <dd><xsl:value-of select="ancestor-or-self::*/gmd:date/gmd:CI_Date/gmd:date"/></dd>
+                                   </xsl:if>
+                                   <xsl:if test="contains(gmd:dateType/gmd:CI_DateTypeCode/@codeListValue,'creation')">
+                                       <dt>Creation Date</dt>
+                                       <dd><xsl:value-of select="ancestor-or-self::*/gmd:date/gmd:CI_Date/gmd:date"/></dd>
+                                   </xsl:if>
+                                   <xsl:if test="contains(gmd:dateType/gmd:CI_DateTypeCode/@codeListValue,'revision')">
+                                       <dt>Revision Date</dt>
+                                       <dd><xsl:value-of select="ancestor-or-self::*/gmd:date/gmd:CI_Date/gmd:date"/></dd>
+                                   </xsl:if>
+                               </xsl:for-each>
+                              
+                              <xsl:if test="gmd:edition">
+                                  <dt>Edition</dt>
+                                  <dd>
+                                      <xsl:value-of select="gmd:edition"/>
+                                  </dd>
+                              </xsl:if>
+                              
+                              <xsl:if test="gmd:identifier/gmd:MD_Identifier/gmd:code">
+                                <dt>Identifier</dt>
+                                <dd>
+                                  <xsl:value-of select="gmd:identifier/gmd:MD_Identifier/gmd:code"/>
+                                </dd>
+                              </xsl:if>
+                              
+                              <xsl:for-each select="gmd:presentationForm/gmd:CI_PresentationFormCode/@codeListValue">
+                                  <dt>Geospatial Data Presentation Form</dt>
+                                  <dd><xsl:value-of select="."/></dd>
+                              </xsl:for-each> 
+                              
+                              <xsl:for-each select="gmd:collectiveTitle">
+                                  <dt>Collection Title</dt>
+                                  <dd><xsl:value-of select="."/></dd>
+                              </xsl:for-each> 
+                              
+                              <xsl:for-each select="gmd:otherCitationDetails">
+                                  <dt>Other Citation Details</dt>
+                                  <dd>
+                                      <xsl:value-of select="."/>
+                                  </dd>
+                              </xsl:for-each>
+                              
+                              <xsl:for-each select="gmd:series/gmd:CI_Series">
+                                  <dt>Series</dt>
+                                  <dd>
+                                      <dl>
+                                          <dd>
+                                              <dt>Series Title</dt>
+                                              <dd><xsl:value-of select="gmd:name"/></dd>
+                                              <dt>Issue</dt>
+                                              <dd><xsl:value-of select="gmd:issueIdentification"/></dd>
+                                          </dd>
+                                      </dl>
+                                  </dd>
+                              </xsl:for-each>
+                          </dl>
+                      </dd>
                   </xsl:for-each>
-                </xsl:when>
-              </xsl:choose>
-            </blockquote>
-          </blockquote>    
-        </xsl:for-each>
-      <xsl:for-each select="gmd:verticalElement">
-        <xsl:if test="gmd:EX_VerticalExtent/gmd:minimumValue != 0 or gmd:EX_VerticalExtent/gmd:maximumValue != 0">
-          <p><b>Vertical Element:</b></p>
-          <blockquote>
-            <b>Minimum Value: </b>
-            <xsl:call-template name="strip-digits">
-              <xsl:with-param name="element" select="gmd:EX_VerticalExtent/gmd:minimumValue"/>
-              <xsl:with-param name="num-digits" select="5"/>
-            </xsl:call-template><br/>
-            <b>Maximum Value: </b>
-            <xsl:call-template name="strip-digits">
-              <xsl:with-param name="element" select="gmd:EX_VerticalExtent/gmd:maximumValue"/>
-              <xsl:with-param name="num-digits" select="5"/>
-            </xsl:call-template><br/>
-            <xsl:choose>
-              <xsl:when test="string-length( gmd:EX_VerticalExtent/gmd:verticalCRS )">
-                <b>Coordinate Reference System (CRS): </b><xsl:value-of select="gmd:EX_VerticalExtent/gmd:verticalCRS"/><br/>
-              </xsl:when>
-              <xsl:otherwise>
-                <b>Coordinate Reference System (CRS): </b><xsl:value-of select="gmd:EX_VerticalExtent/gmd:verticalCRS/@gco:nilReason"/><br/>
-              </xsl:otherwise>
-            </xsl:choose>
-          </blockquote>
-        </xsl:if>
-      </xsl:for-each>
-      </blockquote>    
-    </xsl:for-each>
-    </font>
-  </xsl:template>
+                    
 
-  <xsl:template match="gmd:supplementalInformation">
-    <h4>Supplemental Information:</h4>
-    <p><xsl:value-of select="."/></p>
-  </xsl:template>
+                    <xsl:for-each select="gmd:identificationInfo/gmd:MD_DataIdentification/gmd:abstract">
+                        <dt>Abstract</dt>
+                        <dd><xsl:value-of select="."/></dd>
+                    </xsl:for-each>                    
+                    
+                   <xsl:for-each select="gmd:identificationInfo/gmd:MD_DataIdentification/gmd:purpose">
+                        <dt>Purpose</dt>
+                        <dd><xsl:value-of select="."/></dd>
+                    </xsl:for-each>
+                    <xsl:for-each select="gmd:identificationInfo/gmd:MD_DataIdentification/gmd:supplementalInformation">
+                        <dt>Supplemental Information</dt>
+                        <dd>
+                            <xsl:value-of select="."/>
+                        </dd>
+                    </xsl:for-each>
+                    
+                    <xsl:for-each select="gmd:identificationInfo/gmd:MD_DataIdentification/gmd:spatialResolution/gmd:MD_Resolution/gmd:equivalentScale/gmd:MD_RepresentativeFraction/gmd:denominator">
+                        <dt>Scale Denominator</dt>
+                        <dd>
+                            <xsl:value-of select="."/>
+                        </dd>
+                    </xsl:for-each>
+                   
+                    <xsl:for-each select="gmd:identificationInfo/gmd:MD_DataIdentification/gmd:extent/gmd:EX_Extent/gmd:temporalElement/gmd:EX_TemporalExtent/gmd:extent">
+                                    <dt>Temporal Extent</dt>
+                                    <dd>
+                                        <dl>
+                                            <xsl:if test="ancestor-or-self::*/gmd:description">
+                                            <dt>Currentness Reference</dt>
+                                            <dd><xsl:value-of select="ancestor-or-self::*/gmd:description"/></dd>
+                                            </xsl:if>
+                                            <xsl:choose>
+                                            <xsl:when test="gml:TimePeriod">
+                                            <dt>Time Period</dt>
+                                                    <dd>
+                                                        <dl>
+                                                            <dt>Begin</dt>
+                                                            <dd>
+                                                                <xsl:value-of select="gml:TimePeriod/gml:beginPosition"/>
+                                                            </dd>
+                                                            <dt>End</dt>
+                                                            <dd>
+                                                                <xsl:value-of select="gml:TimePeriod/gml:endPosition"/>
+                                                            </dd>
+                                                        </dl>
+                                                    </dd>    
+                                                </xsl:when>
+                                                <xsl:when test="gml:TimeInstant">
+                                                    <dt>Time Instant</dt>
+                                                    <dd><xsl:value-of select="gml:TimeInstant/gml:timePosition"/></dd>
+                                                </xsl:when>
+                                            </xsl:choose>
+                                        </dl>
+                                    </dd>
+                                </xsl:for-each>
+                            
+                        
+                    <xsl:for-each select="gmd:identificationInfo/gmd:MD_DataIdentification/gmd:extent/gmd:EX_Extent/gmd:geographicElement/gmd:EX_GeographicBoundingBox">
+                            <dt>Bounding Box</dt>
+                            <dd>
+                                <dl>
+                                    <dt>West</dt>
+                                    <dd>
+                                        <xsl:value-of select="gmd:westBoundLongitude"/>
+                                    </dd>
+                                    <dt>East</dt>
+                                    <dd>
+                                        <xsl:value-of select="gmd:eastBoundLongitude"/>
+                                    </dd>
+                                    <dt>North</dt>
+                                    <dd>
+                                        <xsl:value-of select="gmd:northBoundLatitude"/>
+                                    </dd>
+                                    <dt>South</dt>
+                                    <dd>
+                                        <xsl:value-of select="gmd:southBoundLatitude"/>
+                                    </dd>
+                                </dl>
+                            </dd>
+                        </xsl:for-each>  
+                    
+                  <xsl:if test="gmd:identificationInfo/gmd:MD_DataIdentification/gmd:topicCategory/gmd:MD_TopicCategoryCode"> 
+                  <dt>ISO Topic Category</dt>
+                  <xsl:for-each select="gmd:identificationInfo/gmd:MD_DataIdentification/gmd:topicCategory/gmd:MD_TopicCategoryCode">
+                      <dd>
+                          <xsl:value-of select="."/>
+                      </dd>
+                  </xsl:for-each>
+                    </xsl:if> 
+                    
 
-  <xsl:template match="gmd:identificationInfo/srv:SV_ServiceIdentification">
-    <p><b><i>Service Identification:</i></b></p>
-    <font>
-    <blockquote>
-      <p><b>Identifier: </b><xsl:value-of select="@id"/></p>
-      <p><b>Service Type: </b><xsl:value-of select="srv:serviceType"/></p>
-      <xsl:for-each select="srv:containsOperations/srv:SV_OperationMetadata">
-        <p><b>Contains Operation:</b></p>
-        <blockquote>
-          <p><b>Operation Name: </b><xsl:value-of select="srv:operationName"/></p>
-          <xsl:call-template name="CI_OnlineResource">
-            <xsl:with-param name="element" select="srv:connectPoint/gmd:CI_OnlineResource"/>
-          </xsl:call-template>
-        </blockquote>
-      </xsl:for-each> 
-    </blockquote>
-    </font>
-  </xsl:template>
+                    <xsl:for-each select="gmd:identificationInfo/gmd:MD_DataIdentification/gmd:descriptiveKeywords/gmd:MD_Keywords">
 
-  <!-- DATA_QUALITY_INFORMATION: ********************************************-->
 
-  <xsl:template match="gmd:dataQualityInfo/gmd:DQ_DataQuality">
-    <hr/>
-    <h3><a name="Data_Quality_Information"></a>Data Quality Information:</h3>
-    <xsl:apply-templates select="gmd:scope"/>
-    <xsl:if test="string-length( gmd:report )">
-      <h4>Reports:</h4>
-      <xsl:apply-templates select="gmd:report"/>
-    </xsl:if>
-    <xsl:apply-templates select="gmd:lineage"/>
-    <p><a href="javascript:void(0)" onClick="window.scrollTo( 0, 0 ); this.blur(); return false;">Back to Top</a></p>
-  </xsl:template>
+                                <xsl:choose>
+                                    <xsl:when test="ancestor-or-self::*/gmd:type/gmd:MD_KeywordTypeCode[@codeListValue='theme']">
+                                        <dt>Theme Keyword</dt>
+                                        <xsl:for-each select="gmd:keyword">
 
-  <xsl:template match="gmd:scope">
-    <xsl:if test="string-length( . )">
-      <h4>Scope:</h4>
-      <p><xsl:value-of select="."/></p>
-    </xsl:if>
-  </xsl:template>
+                                            <dd>
+                                                <xsl:value-of select="."/>
+                                                <xsl:if test="position()=last()">
+                                                    <dl>
+                                                        <dt>Theme Keyword Thesaurus</dt>
+                                                        <dd> <xsl:value-of select="ancestor-or-self::*/gmd:thesaurusName/gmd:CI_Citation/gmd:title"/></dd>
+                                                    </dl>
+                                                </xsl:if>
+                                            </dd>
+                                        </xsl:for-each>
+             
+                                    </xsl:when>  
+                                    
+                                    <xsl:when test="ancestor-or-self::*/gmd:type/gmd:MD_KeywordTypeCode[@codeListValue='place']">
+                                        <dt>Place Keyword</dt>
+                                        <xsl:for-each select="gmd:keyword">
 
-  <xsl:template match="gmd:report">
-    <xsl:for-each select="gmd:DQ_CompletenessCommission">
-      <p><b><i>Completeness Commission:</i></b></p>
-      <blockquote>
-        <p><b>Evaluation Method Description:</b></p>
-        <p><xsl:value-of select="gmd:evaluationMethodDescription"/></p>
-        <xsl:if test="string-length( gmd:result )">
-          <p><b>Result:</b></p>
-          <p><xsl:value-of select="gmd:result"/></p>
-        </xsl:if>
-      </blockquote>
-    </xsl:for-each>
-    <xsl:for-each select="gmd:DQ_CompletenessOmission">
-      <p><b><i>Completeness Omission:</i></b></p>
-      <blockquote>
-        <p><b>Evaluation Method Description:</b></p>
-        <p><xsl:value-of select="gmd:evaluationMethodDescription"/></p>
-        <xsl:if test="string-length( gmd:result )">
-          <p><b>Result:</b></p>
-          <p><xsl:value-of select="gmd:result"/></p>
-        </xsl:if>
-      </blockquote>
-    </xsl:for-each>
-    <xsl:for-each select="gmd:DQ_ConceptualConsistency">
-      <p><b><i>Conceptual Consistency:</i></b></p>
-      <blockquote>
-        <p><b>Measure Description:</b></p>
-        <p><xsl:value-of select="gmd:measureDescription"/></p>
-        <xsl:if test="string-length( gmd:result )">
-          <p><b>Result:</b></p>
-          <p><xsl:value-of select="gmd:result"/></p>
-        </xsl:if>
-      </blockquote>
-    </xsl:for-each>
-  </xsl:template>
+                                            <dd>
+                                                <xsl:value-of select="."/>
+                                                <xsl:if test="position()=last()">
+                                                    <dl>
+                                                        <dt>Place Keyword Thesaurus</dt>
+                                                        <dd> <xsl:value-of select="ancestor-or-self::*/gmd:thesaurusName/gmd:CI_Citation/gmd:title"/></dd>
+                                                    </dl>
+                                                </xsl:if>
+                                            </dd>
+                                        </xsl:for-each>
+                                    </xsl:when>  
+                                    
+                                    <xsl:when test="ancestor-or-self::*/gmd:type/gmd:MD_KeywordTypeCode[@codeListValue='temporal']">
+                                        <dt>Temporal Keyword</dt>
+                                        <xsl:for-each select="gmd:keyword">
 
-  <xsl:template match="gmd:lineage">
-    <xsl:for-each select="gmd:LI_Lineage">
-      <h4>Lineage:</h4>
-      <xsl:for-each select="gmd:processStep/gmd:LI_ProcessStep">
-        <p><b><i>Process Step:</i></b></p>
-        <p><xsl:value-of select="gmd:description"/></p>
-        <blockquote>
-          <xsl:for-each select="gmd:dateTime">
-            <xsl:if test="string-length( . )">
-              <p><b>Date And Time: </b><xsl:value-of select="."/></p>   
+                                            <dd>
+                                                <xsl:value-of select="."/>
+                                            </dd>
+                                        </xsl:for-each>
+                                    </xsl:when> 
+                                </xsl:choose>                         
+                            
+                        
+                    </xsl:for-each>      
+                                        
+                  <xsl:for-each select="gmd:identificationInfo/gmd:MD_DataIdentification/gmd:resourceConstraints">
+                      
+                      <xsl:if test="gmd:MD_LegalConstraints">
+                          <dt>Legal Constraints</dt>
+                      </xsl:if>
+
+                      <xsl:if test="gmd:MD_SecurityConstraints">
+                          <dt>Security Constraints</dt>
+                      </xsl:if>
+                      
+                      <xsl:if test="gmd:MD_Constraints">
+                          <dt>Resource Constraints</dt>
+                      </xsl:if>
+                      
+                      <dd>
+                          <dl>
+                              <xsl:if test="*/gmd:useLimitation">
+                              <dt>Use Limitation</dt>
+                              <dd>
+                                  <xsl:value-of select="*/gmd:useLimitation"/>
+                              </dd>
+                              </xsl:if>
+                              <xsl:if test="*/gmd:accessConstraints">
+                              <dt>Access Restrictions</dt>
+                              <dd>
+                                  <xsl:value-of select="*/gmd:accessConstraints/gmd:MD_RestrictionCode/@codeListValue"/>
+                              </dd>
+                              </xsl:if>
+                              <xsl:if test="*/gmd:useConstraints">
+                              <dt>Use Restrictions</dt>
+                              <dd>
+                                  <xsl:value-of select="*/gmd:useConstraints/gmd:MD_RestrictionCode/@codeListValue"/>
+                              </dd>
+                              </xsl:if>  
+                              <xsl:if test="*/gmd:otherConstraints">
+                              <dt>Other Restrictions</dt>
+                              <dd>
+                                  <xsl:value-of select="*/gmd:otherConstraints"/>
+                              </dd>
+                              </xsl:if>
+                          </dl>
+                      </dd>
+                  </xsl:for-each>
+               
+                    
+                    <xsl:for-each select="gmd:identificationInfo/gmd:MD_DataIdentification/gmd:status">
+                        <dt>Status</dt>
+                        <dd><xsl:value-of select="gmd:MD_ProgressCode/@codeListValue"/></dd>
+                    </xsl:for-each>
+                    
+                    <xsl:for-each select="gmd:identificationInfo/gmd:MD_DataIdentification/gmd:resourceMaintenance/gmd:MD_MaintenanceInformation/gmd:maintenanceAndUpdateFrequency">
+                        <dt>Maintenance and Update Frequency</dt>
+                        <dd>
+                            <xsl:value-of select="gmd:MD_MaintenanceFrequencyCode/@codeListValue"/>
+                        </dd>
+                    </xsl:for-each>                  
+                    
+               <xsl:for-each select="gmd:identificationInfo/gmd:MD_DataIdentification/gmd:aggregationInfo/gmd:MD_AggregateInformation/gmd:associationType/gmd:DS_AssociationTypeCode[@codeListValue='largerWorkCitation']">
+                      <dt>Collection</dt>
+                      <dd>
+                          <dl>
+                              <dt>Collection Title</dt>
+                              <dd><xsl:value-of select="ancestor-or-self::*/gmd:aggregateDataSetName/gmd:CI_Citation/gmd:title"/></dd>
+                              <dt>URL</dt>
+                              <dd><xsl:value-of select="ancestor-or-self::*/gmd:aggregateDataSetName/gmd:CI_Citation/gmd:identifier/gmd:MD_Identifier/gmd:code"/></dd>
+                              <xsl:for-each select="ancestor-or-self::*/gmd:aggregateDataSetName/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:role/gmd:CI_RoleCode[@codeListValue='originator']">
+                              <dt>Originator</dt>
+                                  <dd><xsl:value-of select="ancestor-or-self::*/gmd:organisationName | ancestor-or-self::*/gmd:individualName"/></dd>
+                              </xsl:for-each>
+                              <xsl:for-each select="ancestor-or-self::*/gmd:aggregateDataSetName/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:role/gmd:CI_RoleCode[@codeListValue='publisher']">
+                              <dt>Publisher</dt>
+                                  <dd><xsl:value-of select="ancestor-or-self::*/gmd:organisationName | ancestor-or-self::*/gmd:individualName"/></dd>
+                              </xsl:for-each>
+                              <xsl:for-each select="ancestor-or-self::*/gmd:aggregateDataSetName/gmd:CI_Citation/gmd:date">
+                                  <xsl:if test="contains(descendant-or-self::*/gmd:dateType/gmd:CI_DateTypeCode/@codeListValue,'publication')">
+                                      <dt>Publication Date</dt>
+                                      <dd><xsl:value-of select="gmd:CI_Date/gmd:date"/></dd>
+                                  </xsl:if>
+                                  <xsl:if test="contains(descendant-or-self::*/gmd:dateType/gmd:CI_DateTypeCode/@codeListValue,'creation')">
+                                      <dt>Creation Date</dt>
+                                      <dd><xsl:value-of select="gmd:CI_Date/gmd:date"/></dd>
+                                  </xsl:if>
+                                  <xsl:if test="contains(descendant-or-self::*/gmd:dateType/gmd:CI_DateTypeCode/@codeListValue,'revision')">
+                                      <dt>Revision Date</dt>
+                                      <dd><xsl:value-of select="gmd:CI_Date/gmd:date"/></dd>
+                                  </xsl:if>
+                              </xsl:for-each>
+                              <xsl:for-each select="ancestor-or-self::*/gmd:aggregateDataSetName/gmd:CI_Citation/gmd:series/gmd:CI_Series">
+                                  <dt>Series</dt>
+                                  <dd>
+                                      <dl>
+                                          <dd>
+                                              <dt>Series Title</dt>
+                                              <dd><xsl:value-of select="ancestor-or-self::*/gmd:name"/></dd>
+                                              <dt>Issue</dt>
+                                              <dd><xsl:value-of select="ancestor-or-self::*/gmd:issueIdentification"/></dd>
+                                          </dd>
+                                      </dl>
+                                  </dd>
+                              </xsl:for-each>
+                         </dl>
+                      </dd>
+                  </xsl:for-each>
+                    
+                    <xsl:for-each select="gmd:identificationInfo/gmd:MD_DataIdentification/gmd:aggregationInfo/gmd:MD_AggregateInformation/gmd:associationType/gmd:DS_AssociationTypeCode[@codeListValue='crossReference']">
+                        <dt>Cross Reference</dt>
+                        <dd>
+                            <dl>
+                                <dt>Title</dt>
+                                <dd><xsl:value-of select="ancestor-or-self::*/gmd:aggregateDataSetName/gmd:CI_Citation/gmd:title"/></dd>
+                                <dt>URL</dt>
+                                <dd><xsl:value-of select="ancestor-or-self::*/gmd:aggregateDataSetName/gmd:CI_Citation/gmd:identifier/gmd:MD_Identifier/gmd:code"/></dd>
+                                <xsl:for-each select="ancestor-or-self::*/gmd:aggregateDataSetName/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:role/gmd:CI_RoleCode[@codeListValue='originator']">
+                                    <dt>Originator</dt>
+                                    <dd><xsl:value-of select="ancestor-or-self::*/gmd:organisationName | ancestor-or-self::*/gmd:individualName"/></dd>
+                                </xsl:for-each>
+                                <xsl:for-each select="ancestor-or-self::*/gmd:aggregateDataSetName/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:role/gmd:CI_RoleCode[@codeListValue='publisher']">
+                                    <dt>Publisher</dt>
+                                    <dd><xsl:value-of select="ancestor-or-self::*/gmd:organisationName | ancestor-or-self::*/gmd:individualName"/></dd>
+                                </xsl:for-each>
+                                <xsl:for-each select="ancestor-or-self::*/gmd:aggregateDataSetName/gmd:CI_Citation/gmd:date">
+                                    <xsl:if test="contains(descendant-or-self::*/gmd:dateType/gmd:CI_DateTypeCode/@codeListValue,'publication')">
+                                        <dt>Publication Date</dt>
+                                        <dd><xsl:value-of select="gmd:CI_Date/gmd:date"/></dd>
+                                    </xsl:if>
+                                    <xsl:if test="contains(descendant-or-self::*/gmd:dateType/gmd:CI_DateTypeCode/@codeListValue,'creation')">
+                                        <dt>Creation Date</dt>
+                                        <dd><xsl:value-of select="gmd:CI_Date/gmd:date"/></dd>
+                                    </xsl:if>
+                                    <xsl:if test="contains(descendant-or-self::*/gmd:dateType/gmd:CI_DateTypeCode/@codeListValue,'revision')">
+                                        <dt>Revision Date</dt>
+                                        <dd><xsl:value-of select="gmd:CI_Date/gmd:date"/></dd>
+                                    </xsl:if>
+                                </xsl:for-each>
+                            </dl>
+                        </dd>
+                    </xsl:for-each> 
+                  <dt>Language</dt>
+                  <dd>
+                      <xsl:value-of select="gmd:identificationInfo/gmd:MD_DataIdentification/gmd:language"/>
+                  </dd>
+             
+                  <xsl:if test="gmd:identificationInfo/gmd:MD_DataIdentification/gmd:credit">
+                      <dt>Credit</dt>
+                      <dd><xsl:value-of select="gmd:identificationInfo/gmd:MD_DataIdentification/gmd:credit"/></dd>
+                  </xsl:if>
+                  
+                  <xsl:for-each select="gmd:identificationInfo/gmd:MD_DataIdentification/gmd:pointOfContact">
+                      <dt>Point of Contact</dt>
+                      <dd>
+                          <dl>
+                              <xsl:for-each select="gmd:CI_ResponsibleParty">
+                                  <dt>Contact</dt>
+                                  <dd>
+                                      <xsl:value-of select="gmd:organisationName | gmd:individualName"/>
+                                  </dd>
+                                  <xsl:if test="gmd:positionName">
+                                      <dt>Position Name</dt>
+                                      <dd>
+                                          <xsl:value-of select="gmd:positionName"/>
+                                      </dd>  
+                                  </xsl:if>
+                                  
+                                  <xsl:if test="gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:deliveryPoint">
+                                      <dt>Delivery Point</dt>
+                                      <dd>
+                                          <xsl:value-of select="gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:deliveryPoint"/>
+                                      </dd>
+                                  </xsl:if>   
+                                  
+                                  <xsl:if test="gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:city">
+                                      <dt>City</dt>
+                                      <dd>
+                                          <xsl:value-of select="gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:city"/>
+                                      </dd>
+                                  </xsl:if>  
+                                  <xsl:if test="gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:administrativeArea">
+                                      <dt>Administrative Area</dt>
+                                      <dd>
+                                          <xsl:value-of select="gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:administrativeArea"/>
+                                      </dd>
+                                  </xsl:if>
+                                  <xsl:if test="gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:postalCode">
+                                      <dt>Postal Code</dt>
+                                      <dd><xsl:value-of select="gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:postalCode"/></dd>
+                                  </xsl:if>
+                                  <xsl:if test="gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:country">
+                                      <dt>Country</dt>
+                                      <dd>
+                                          <xsl:value-of select="gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:country"/>
+                                      </dd>
+                                  </xsl:if>
+                                  <xsl:if test="gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:electronicMailAddress">
+                                      <dt>Email</dt>
+                                      <dd>
+                                          <xsl:value-of select="gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:electronicMailAddress"/>
+                                      </dd>
+                                  </xsl:if>
+                                  <xsl:if test="gmd:contactInfo/gmd:CI_Contact/gmd:phone/gmd:CI_Telephone/gmd:voice">
+                                      <dt>Phone</dt>
+                                      <dd>
+                                          <xsl:value-of select="gmd:contactInfo/gmd:CI_Contact/gmd:phone/gmd:CI_Telephone/gmd:voice"/>
+                                      </dd>
+                                  </xsl:if>    
+                              </xsl:for-each>
+                          </dl>
+                      </dd>
+                  </xsl:for-each>
+                </dl>
+          </dd>
+        </div>
+            
+ <!-- Spatial Reference Info -->
+            
+            <xsl:if test="gmd:referenceSystemInfo">
+              <div id="iso-spatial-reference-info">
+                <dt>Spatial Reference Information</dt>
+                <dd>
+                    <dl>
+                        <dt>Reference System Identifier</dt>
+                        <dd>
+                            <dl>
+                                <dt>Code</dt>
+                                <dd><xsl:value-of select="gmd:referenceSystemInfo/gmd:MD_ReferenceSystem/gmd:referenceSystemIdentifier/gmd:RS_Identifier/gmd:code"/></dd>
+                                <dt>Code Space</dt>
+                                <dd><xsl:value-of select="gmd:referenceSystemInfo/gmd:MD_ReferenceSystem/gmd:referenceSystemIdentifier/gmd:RS_Identifier/gmd:codeSpace"/></dd>
+                                <dt>Version</dt>
+                                <dd><xsl:value-of select="gmd:referenceSystemInfo/gmd:MD_ReferenceSystem/gmd:referenceSystemIdentifier/gmd:RS_Identifier/gmd:version"/></dd>
+                            </dl>
+                        </dd>
+                    </dl>
+                </dd>
+              </div>
             </xsl:if>
-          </xsl:for-each>
-          <xsl:for-each select="gmd:rationale">
-            <xsl:if test="string-length( . )">
-              <p><b>Rationale:</b></p>
-              <p><xsl:value-of select="."/></p>
+            
+            <!-- Data Quality Info -->
+            <xsl:if test="gmd:dataQualityInfo/gmd:DQ_DataQuality">
+              <div id="iso-data-quality-info">
+                <dt>Data Quality Information</dt>
+                <dd>
+                    <dl>
+                        <xsl:if test="gmd:DQ_Scope/gmd:level">
+                            <dt>Hierarchy Level</dt>
+                            <dd>
+                                <xsl:value-of select="gmd:DQ_Scope/gmd:level/gmd:MD_ScopeCode[@codeListValue]"/>
+                            </dd>
+                        </xsl:if>
+                        <xsl:for-each select="gmd:dataQualityInfo/gmd:DQ_DataQuality/gmd:report">
+                            <xsl:if test="gmd:DQ_QuantitativeAttributeAccuracy">
+                                <dt>Quantitative Attribute Accuracy Report</dt>
+                                <dd>
+                                    <dl>
+                                        <xsl:if test="gmd:DQ_QuantitativeAttributeAccuracy/gmd:evaluationMethodDescription/text()">
+                                            <dt>Evaluation Method</dt>
+                                            <dd><xsl:value-of select="gmd:DQ_QuantitativeAttributeAccuracy/gmd:evaluationMethodDescription"/></dd>
+                                        </xsl:if>
+                                        <xsl:if test="gmd:DQ_QuantitativeAttributeAccuracy/gmd:result/text()">
+                                            <dt>Result</dt>
+                                            <dd><xsl:value-of select="gmd:DQ_QuantitativeAttributeAccuracy/gmd:result"/></dd>
+                                        </xsl:if>
+                                    </dl>
+                                </dd>
+                            </xsl:if>
+                            
+                            <xsl:if test="gmd:DQ_AbsoluteExternalPositionalAccuracy">
+                                <dt>Absolute External Positional Accuracy</dt>
+                                <dd>
+                                    <dl>
+                                        <xsl:if test="gmd:DQ_AbsoluteExternalPositionalAccuracy/gmd:evaluationMethodDescription/text()">
+                                            <dt>Evaluation Method</dt>
+                                            <dd><xsl:value-of select="gmd:DQ_AbsoluteExternalPositionalAccuracy/gmd:evaluationMethodDescription"/></dd>
+                                        </xsl:if>
+                                        <xsl:if test="gmd:DQ_AbsoluteExternalPositionalAccuracy/gmd:result/text()">
+                                            <dt>Result</dt>
+                                            <dd><xsl:value-of select="gmd:DQ_AbsoluteExternalPositionalAccuracy/gmd:result"/></dd>
+                                        </xsl:if>
+                                    </dl>
+                                </dd>
+                            </xsl:if>
+                            
+                            <xsl:if test="gmd:DQ_CompletenessCommission">
+                                <dt>Completeness Commission</dt>
+                                <dd>
+                                    <dl>
+                                        <xsl:if test="gmd:DQ_CompletenessCommission/gmd:evaluationMethodDescription/text()">
+                                            <dt>Evaluation Method</dt>
+                                            <dd><xsl:value-of select="gmd:DQ_CompletenessCommission/gmd:evaluationMethodDescription"/></dd>
+                                        </xsl:if>
+                                        <xsl:if test="gmd:DQ_CompletenessCommission/gmd:result/text()">
+                                            <dt>Result</dt>
+                                            <dd><xsl:value-of select="gmd:DQ_CompletenessCommission/gmd:result"/></dd>
+                                        </xsl:if>
+                                    </dl>
+                                </dd>
+                            </xsl:if>
+                        </xsl:for-each>    
+                        <xsl:for-each select="gmd:dataQualityInfo/gmd:DQ_DataQuality/gmd:lineage/gmd:LI_Lineage">
+                            <dt>Lineage</dt>
+                            <dd>
+                                <dl>
+                                    <xsl:if test="gmd:statement">
+                                        <dt>Statement</dt>
+                                        <dd>
+                                            <xsl:value-of select="gmd:statement"/>
+                                        </dd>
+                                    </xsl:if>
+                                    <xsl:for-each select="gmd:processStep/gmd:LI_ProcessStep">
+                                        <dt>Process Step</dt>
+                                        <dd>
+                                            <dl>
+                                                <xsl:if test="gmd:description">
+                                                <dt>Description</dt>
+                                                <dd>
+                                                    <xsl:value-of select="gmd:description"/>
+                                                </dd>
+                                                </xsl:if>
+                                                
+                                                <xsl:for-each select="gmd:CI_ResponsibleParty">
+                                                    <dt>Processor</dt>
+                                                    <dd>
+                                                        <xsl:value-of select="gmd:individualName | gmd:organisationName"/>
+                                                    </dd>
+                                                </xsl:for-each>
+
+                                                <xsl:if test="gmd:dateTime">
+                                                    <dt>Process Date</dt>
+                                                    <dd>
+                                                        <xsl:value-of select="gmd:dateTime"/>
+                                                    </dd>
+                                                </xsl:if>
+                                            </dl>
+                                        </dd>
+                                    </xsl:for-each>
+                                    <xsl:for-each select="gmd:source/gmd:LI_Source/gmd:sourceCitation"> 
+                                        <dt>Source</dt>
+                                        <dd>
+                                            <dl>
+                                                <dt>Title</dt>
+                                                <dd>
+                                                    <xsl:value-of select="gmd:CI_Citation/gmd:title"/>
+                                                </dd>
+                                                <xsl:for-each select="gmd:CI_Citation/gmd:date/gmd:CI_Date">
+                                                    <xsl:if test="contains(gmd:dateType/gmd:CI_DateTypeCode/@codeListValue,'publication')">
+                                                        <dt>Publication Date</dt>
+                                                        <dd><xsl:value-of select="ancestor-or-self::*/gmd:date/gmd:CI_Date/gmd:date"/></dd>
+                                                    </xsl:if>
+                                                    <xsl:if test="contains(gmd:dateType/gmd:CI_DateTypeCode/@codeListValue,'creation')">
+                                                        <dt>Creation Date</dt>
+                                                        <dd><xsl:value-of select="ancestor-or-self::*/gmd:date/gmd:CI_Date/gmd:date"/></dd>
+                                                    </xsl:if>
+                                                    <xsl:if test="contains(gmd:dateType/gmd:CI_DateTypeCode/@codeListValue,'revision')">
+                                                        <dt>Revision Date</dt>
+                                                        <dd><xsl:value-of select="ancestor-or-self::*/gmd:date/gmd:CI_Date/gmd:date"/></dd>
+                                                    </xsl:if>
+                                                </xsl:for-each>
+                                                <xsl:for-each select="gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:role/gmd:CI_RoleCode[@codeListValue='originator']">
+                                                    <dt>Originator</dt>
+                                                    <dd><xsl:value-of select="ancestor-or-self::*/gmd:organisationName | ancestor-or-self::*/gmd:individualName"/></dd>
+                                                </xsl:for-each>
+                                                
+                                                <xsl:for-each select="gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:role/gmd:CI_RoleCode[@codeListValue='publisher']">
+                                                    <dt>Publisher</dt>
+                                                    <dd><xsl:value-of select="ancestor-or-self::*/gmd:organisationName | ancestor-or-self::*/gmd:individualName"/></dd>
+                                                    <xsl:if test="ancestor-or-self::*/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:city">
+                                                        <dt>Place of Publication</dt>   
+                                                        <dd><xsl:value-of select="ancestor-or-self::*/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:city"/></dd>    
+                                                    </xsl:if>
+                                                </xsl:for-each>
+                                                
+                                                <xsl:if test="gmd:CI_Citation/gmd:identifier/gmd:MD_Identifier/gmd:code">
+                                                    <dt>Identifier</dt>
+                                                    <dd><xsl:value-of select="gmd:CI_Citation/gmd:identifier/gmd:MD_Identifier/gmd:code"/></dd>
+                                                </xsl:if>
+                                                <xsl:if test="ancestor-or-self::*/gmd:description">
+                                                    <dt>Description</dt>
+                                                    <dd><xsl:value-of select="ancestor-or-self::*/gmd:description"/></dd>
+                                                </xsl:if>
+                                            </dl>
+                                        </dd>
+                                    </xsl:for-each>
+                                </dl>
+                            </dd>
+                        </xsl:for-each>
+                        
+                    </dl>
+                </dd>
+              </div>     
+            </xsl:if>    
+            
+            <!-- Distribution -->     
+            <xsl:if test="gmd:distributionInfo">
+              <div id="iso-distribution-info">
+                <dt>Distribution Information</dt>
+                <dd>
+                    <dl>
+                        <xsl:if test="gmd:distributionInfo/gmd:MD_Distribution/gmd:distributionFormat/gmd:MD_Format">
+                            <dt>Format Name</dt>
+                            <dd>
+                                <xsl:value-of select="gmd:distributionInfo/gmd:MD_Distribution/gmd:distributionFormat/gmd:MD_Format/gmd:name"/>
+                            </dd>
+                            <xsl:if test="gmd:distributionInfo/gmd:MD_Distribution/gmd:distributionFormat/gmd:MD_Format/gmd:version/text()">
+                                <dt>Format Version</dt>
+                                <dd>
+                                    <xsl:value-of select="gmd:distributionInfo/gmd:MD_Distribution/gmd:distributionFormat/gmd:MD_Format/gmd:version"/>
+                                </dd>
+                            </xsl:if>    
+                        </xsl:if>    
+                        
+                        <xsl:for-each select="gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor/gmd:MD_Distributor">
+                        <dt>Distributor</dt>
+                        <dd>
+                            <xsl:value-of select="gmd:distributorContact/gmd:CI_ResponsibleParty/gmd:organisationName"/>
+                        </dd>
+                        </xsl:for-each>
+                        
+                      <xsl:for-each select="gmd:distributionInfo/gmd:MD_Distribution/gmd:transferOptions/gmd:MD_DigitalTransferOptions">
+                            <dt>Online Access</dt>
+                            <dd>
+                                <xsl:value-of select="gmd:onLine/gmd:CI_OnlineResource/gmd:linkage/gmd:URL"/>
+                            </dd>
+                            <dt>Protocol</dt>
+                            <dd>
+                                <xsl:value-of select="gmd:onLine/gmd:CI_OnlineResource/gmd:protocol"/>
+                            </dd>
+                            <dt>Name</dt>
+                            <dd>
+                                <xsl:value-of select="gmd:onLine/gmd:CI_OnlineResource/gmd:name"/>
+                            </dd>
+                            <xsl:if test="gmd:onLine/gmd:CI_OnlineResource/gmd:function/gmd:CI_OnLineFunctionCode/@codeListValue">
+                            <dt>Function</dt>
+                            <dd>
+                                <xsl:value-of select="gmd:onLine/gmd:CI_OnlineResource/gmd:function/gmd:CI_OnLineFunctionCode/@codeListValue"/>
+                            </dd>
+                            </xsl:if>
+                          <xsl:if test="gmd:distributionInfo/gmd:MD_Distribution/gmd:transferOptions/gmd:MD_DigitalTransferOptions/gmd:transferSize">
+                              <dt>Transfer Size</dt>
+                              <dd><xsl:value-of select="gmd:distributionInfo/gmd:MD_Distribution/gmd:transferOptions/gmd:MD_DigitalTransferOptions/gmd:transferSize"/></dd>
+                          </xsl:if>
+                        </xsl:for-each>
+                    </dl>
+                </dd>
+              </div>
             </xsl:if>
-          </xsl:for-each>
-        </blockquote>
-      </xsl:for-each>
-      <xsl:for-each select="gmd:statement">
-        <p><b><i>Statement:</i></b></p>
-        <p><xsl:value-of select="."/></p>
-      </xsl:for-each>
-    </xsl:for-each>
-  </xsl:template>
-
-  <!-- SPATIAL_REPRESENTATION_INFORMATION: **********************************-->
-
-  <xsl:template match="gmd:spatialRepresentationInfo/gmd:MD_GridSpatialRepresentation">
-    <hr/>
-    <h3><a name="Spatial_Representation_Information"></a>Spatial Representation Information:</h3>
-    <xsl:apply-templates select="gmd:numberOfDimensions"/>
-    <xsl:if test="string-length( gmd:axisDimensionProperties )">
-      <h4>Axis Dimension Properties:</h4>
-      <xsl:apply-templates select="gmd:axisDimensionProperties"/>
-    </xsl:if>
-    <xsl:apply-templates select="gmd:cellGeometry"/>
-    <!-- Fill these in later when I have actual examples:
-    <xsl:apply-templates select="gmd:transformationParameterAvailability"/>
-    -->
-    <p><a href="javascript:void(0)" onClick="window.scrollTo( 0, 0 ); this.blur(); return false;">Back to Top</a></p>
-  </xsl:template>
-
-  <xsl:template match="gmd:numberOfDimensions">
-    <h4 style="display: inline">Number Of Dimensions:</h4>
-    <p style="display: inline"><xsl:value-of select="."/></p>
-    <p></p>
-  </xsl:template>
-
-  <xsl:template match="gmd:axisDimensionProperties">
-    <xsl:for-each select="gmd:MD_Dimension">
-      <p><b><i>Dimension:</i></b></p>
-      <font>
-      <blockquote>
-        <xsl:for-each select="gmd:dimensionName">
-          <xsl:if test="string-length( . )">
-            <b>Dimension Name: </b><xsl:value-of select="."/> (<a href="http://pacioos.org/metadata/gmxCodelists.html#MD_DimensionNameTypeCode">MD_DimensionNameTypeCode</a>)<br/>
-          </xsl:if>
-        </xsl:for-each>
-        <xsl:for-each select="gmd:dimensionSize">
-          <xsl:if test="string-length( . )">
-            <b>Dimension Size: </b><xsl:value-of select="."/><br/>
-          </xsl:if>
-        </xsl:for-each>
-        <xsl:for-each select="gmd:resolution">
-          <xsl:if test="string-length( gco:Scale )">
-            <b>Resolution: </b>
-            <xsl:call-template name="strip-digits">
-              <xsl:with-param name="element" select="gco:Scale"/>
-              <xsl:with-param name="num-digits" select="5"/>
-            </xsl:call-template>
-            <xsl:choose>
-              <xsl:when test="gco:Scale/@uom = 'decimalDegrees'">
-                <xsl:text>&#176;</xsl:text>
-              </xsl:when>
-              <xsl:otherwise>
-                <xsl:text> </xsl:text><xsl:value-of select="gco:Scale/@uom"/>
-              </xsl:otherwise>
-            </xsl:choose>
-            <br/> 
-          </xsl:if>
-          <xsl:if test="string-length( gco:Measure )">
-            <xsl:variable name="measure">
-              <xsl:call-template name="strip-digits">
-                <xsl:with-param name="element" select="gco:Measure"/>
-                <xsl:with-param name="num-digits" select="5"/>
-              </xsl:call-template>
-            </xsl:variable>
-            <xsl:choose>
-              <xsl:when test="gco:Measure/@uom = '1'">
-                <b>Resolution: </b><xsl:value-of select="$measure"/>
-              </xsl:when>
-              <xsl:otherwise>
-                <b>Resolution: </b><xsl:value-of select="$measure"/><xsl:text> </xsl:text><xsl:value-of select="gco:Measure/@uom"/><br/>
-              </xsl:otherwise>
-            </xsl:choose>
-          </xsl:if>          
-        </xsl:for-each>
-      </blockquote>
-      </font>
-    </xsl:for-each>
-  </xsl:template>
-  
-  <xsl:template match="gmd:cellGeometry">
-    <h4 style="display: inline">Cell Geometry:</h4>
-    <p style="display: inline"><xsl:value-of select="gmd:MD_CellGeometryCode"/> (<a href="http://pacioos.org/metadata/gmxCodelists.html#MD_CellGeometryCode">MD_CellGeometryCode</a>)</p>
-    <p></p> 
-  </xsl:template>
-
-  <xsl:template match="gmd:transformationParameterAvailability">
-    <h4>Transformation Parameter Availability:</h4>
-  </xsl:template>
-
-  <!-- CONTENT_INFORMATION: *************************************************-->
-
-  <xsl:template match="gmd:contentInfo">
-    <hr/>
-    <h3><a name="Content_Information"></a>Content Information:</h3>
-    <xsl:apply-templates select="gmd:MI_CoverageDescription"/>
-    <xsl:apply-templates select="gmd:MD_FeatureCatalogueDescription"/>
-    <p><a href="javascript:void(0)" onClick="window.scrollTo( 0, 0 ); this.blur(); return false;">Back to Top</a></p>
-  </xsl:template>
-
-  <xsl:template match="gmd:MI_CoverageDescription">
-    <h4>Coverage Description:</h4>
-    <xsl:apply-templates select="gmd:attributeDescription"/>
-    <xsl:apply-templates select="gmd:contentType"/>
-    <xsl:if test="string-length( gmd:dimension )">
-      <p><b><i>Dimensions:</i></b></p>
-      <ul>
-        <xsl:for-each select="gmd:dimension">
-          <xsl:sort select="gmd:MD_Band/gmd:sequenceIdentifier/gco:MemberName/gco:aName"/>
-          <li><a href="#{gmd:MD_Band/gmd:sequenceIdentifier/gco:MemberName/gco:aName/gco:CharacterString}"><xsl:value-of select="gmd:MD_Band/gmd:sequenceIdentifier/gco:MemberName/gco:aName"/></a></li>
-        </xsl:for-each>
-      </ul>
-    </xsl:if>
-    <xsl:apply-templates select="gmd:dimension"/>
-    <xsl:apply-templates select="gmd:rangeElementDescription"/>
-  </xsl:template>
-
-  <xsl:template match="gmd:attributeDescription">
-    <xsl:if test="string-length( . )">
-      <p><b><i>Attribute Description:</i></b></p>
-      <p><xsl:value-of select="."/></p>
-    </xsl:if>
-  </xsl:template>
-
-  <xsl:template match="gmd:contentType">
-    <xsl:if test="string-length( . )">
-      <p><b><i>Content Type: </i></b><xsl:value-of select="gmd:MD_CoverageContentTypeCode"/> (<a href="http://pacioos.org/metadata/gmxCodelists.html#MD_CoverageContentTypeCode">MD_CoverageContentTypeCode</a>)</p>
-    </xsl:if>
-  </xsl:template>
-
-  <xsl:template match="gmd:dimension">
-    <xsl:if test="string-length( . )">
-      <p><a name="{gmd:MD_Band/gmd:sequenceIdentifier/gco:MemberName/gco:aName/gco:CharacterString}"></a><b><i>Dimension: </i></b></p>
-      <blockquote>
-        <font>
-        <xsl:apply-templates select="gmd:MD_Band"/> 
-        </font>
-      </blockquote>
-    </xsl:if>
-  </xsl:template>
-
-  <xsl:template match="gmd:MD_Band">
-    <xsl:if test="string-length( . )">
-      <xsl:apply-templates select="gmd:sequenceIdentifier"/>
-      <xsl:apply-templates select="gmd:units"/>
-      <xsl:if test="string-length( gmd:descriptor )">
-        <b>Descriptor:</b><br/>
-        <p><xsl:value-of select="gmd:descriptor"/></p>
-      </xsl:if>
-    </xsl:if>
-  </xsl:template>
-
-  <xsl:template match="gmd:sequenceIdentifier">
-    <xsl:apply-templates select="gco:MemberName"/>
-  </xsl:template>
-
-  <xsl:template match="gco:MemberName">
-    <xsl:if test="string-length( gco:aName )">
-      <b>Attribute Name: </b><xsl:value-of select="gco:aName"/><br/>
-    </xsl:if>
-    <xsl:apply-templates select="gco:attributeType"/>
-  </xsl:template>
-
-  <xsl:template match="gco:attributeType">
-    <xsl:if test="string-length( gco:TypeName/gco:aName )">
-      <b>Attribute Type: </b><xsl:value-of select="gco:TypeName/gco:aName"/><br/>
-    </xsl:if>
-  </xsl:template>
-
-  <xsl:template match="gmd:units">
-    <xsl:choose>
-      <xsl:when test="string-length( . )">
-        <b>Units: </b><xsl:value-of select="."/><br/>
-      </xsl:when>
-      <xsl:otherwise>
-        <xsl:variable name="unitsUrl">
-          <xsl:choose>
-            <xsl:when test="contains( @xlink:href, 'someUnitsDictionary')">
-              <xsl:value-of select="substring-after( @xlink:href, '#' )"/>
-            </xsl:when>
-            <xsl:otherwise>
-              <xsl:value-of select="@xlink:href"/>
-            </xsl:otherwise>
-          </xsl:choose>
-        </xsl:variable>
-        <xsl:choose>
-          <xsl:when test="contains( $unitsUrl, 'http' )">
-            <b>Units: </b><a href="{$unitsUrl}"><xsl:value-of select="$unitsUrl"/></a><br/>
-          </xsl:when>
-          <xsl:otherwise>
-            <b>Units: </b><!--<xsl:value-of select="$unitsUrl"/><br/>-->
-            <!-- Replace URL encodings with text equivalents: -->
-            <xsl:variable name="unitsUrlDecoded">
-              <xsl:call-template name="replace-string">
-                <xsl:with-param name="element" select="$unitsUrl"/>
-                <xsl:with-param name="old-string">%20</xsl:with-param>
-                <xsl:with-param name="new-string">&#160;</xsl:with-param>
-              </xsl:call-template>
-            </xsl:variable>
-            <xsl:variable name="unitsUrlDecoded2">
-              <xsl:call-template name="replace-string">
-                <xsl:with-param name="element" select="$unitsUrlDecoded"/>
-                <xsl:with-param name="old-string">%3A</xsl:with-param>
-                <xsl:with-param name="new-string">-</xsl:with-param>
-              </xsl:call-template>
-            </xsl:variable>
-            <xsl:value-of select="$unitsUrlDecoded2"/>
-            <br/>
-          </xsl:otherwise>
-        </xsl:choose>
-      </xsl:otherwise>
-    </xsl:choose>
-  </xsl:template>
-
-  <xsl:template match="gmd:rangeElementDescription">
-    <xsl:if test="string-length( . )">
-    </xsl:if>
-  </xsl:template>
-
-  <xsl:template match="gmd:MD_FeatureCatalogueDescription">
-    <h4>Feature Catalogue Description:</h4>
-    <xsl:for-each select="gmd:includedWithDataset">
-      <p>
-        <b><i>Included With Dataset?: </i></b>
-        <xsl:choose>
-          <xsl:when test=".">
-            <xsl:text>Yes</xsl:text>
-          </xsl:when>
-          <xsl:otherwise>
-            <xsl:text>No</xsl:text>
-          </xsl:otherwise>
-        </xsl:choose>
-      </p> 
-    </xsl:for-each>
-    <xsl:for-each select="gmd:featureTypes">
-      <p><b><i>Feature Types: </i></b><xsl:value-of select="gco:LocalName/@codeSpace"/></p>
-    </xsl:for-each>
-    <xsl:for-each select="gmd:featureCatalogueCitation">
-      <p>
-        <b><i>Feature Catalogue Citation: </i></b>
-        <xsl:choose>
-          <xsl:when test="string-length( gmd:CI_Citation )">
-            <xsl:call-template name="CI_Citation">
-              <xsl:with-param name="element" select="gmd:CI_Citation"/>
-            </xsl:call-template>
-          </xsl:when>
-          <xsl:otherwise>
-            <xsl:value-of select="@gco:nilReason"/>
-          </xsl:otherwise>
-        </xsl:choose>
-      </p>
-    </xsl:for-each>
-  </xsl:template>
-
-  <!-- DISTRIBUTION_INFORMATION: ********************************************-->
  
-  <xsl:template match="gmd:distributionInfo/gmd:MD_Distribution">
-    <hr/>
-    <h3><a name="Distribution_Information"></a>Distribution Information:</h3>
-    <xsl:apply-templates select="gmd:distributor"/>
-    <xsl:apply-templates select="gmd:distributionFormat"/>
-    <xsl:apply-templates select="gmd:transferOptions"/>
-    <p><a href="javascript:void(0)" onClick="window.scrollTo( 0, 0 ); this.blur(); return false;">Back to Top</a></p>
-  </xsl:template>
+            <!-- Content Info -->        
+            <xsl:if test="gmd:contentInfo">
+              <div id="iso-content-info">
+                <dt>Content Information</dt>
+                <dd>
+                    <dl>
+                        <xsl:if test="gmd:contentInfo/gmd:MD_FeatureCatalogueDescription">
+                            <dt>Feature Catalog Description</dt>
+                            <dd>
+                                <dl>
+                                    <dt>Compliance Code</dt>
+                                    <dd><xsl:value-of select="gmd:contentInfo/gmd:MD_FeatureCatalogueDescription/gmd:complianceCode"/></dd>
+                                    <dt>Language</dt>
+                                    <dd><xsl:value-of select="gmd:contentInfo/gmd:MD_FeatureCatalogueDescription/gmd:language"/></dd>
+                                    <dt>Included With Dataset</dt>
+                                    <dd><xsl:value-of select="gmd:contentInfo/gmd:MD_FeatureCatalogueDescription/gmd:includedWithDataset"/></dd>
+                                    <dt>Feature Catalog Citation</dt>
+                                    <dd>
+                                        <dl>
+                                            <dt>Title</dt>
+                                            <dd>
+                                                <xsl:value-of select="gmd:contentInfo/gmd:MD_FeatureCatalogueDescription/gmd:featureCatalogueCitation/gmd:CI_Citation/gmd:title"/>
+                                            </dd>
+                                            
+                                            <xsl:for-each select="gmd:contentInfo/gmd:MD_FeatureCatalogueDescription/gmd:featureCatalogueCitation/gmd:CI_Citation/gmd:date/gmd:CI_Date">
+                                                <xsl:if test="contains(gmd:dateType/gmd:CI_DateTypeCode/@codeListValue,'publication')">
+                                                    <dt>Publication Date</dt>
+                                                    <dd><xsl:value-of select="ancestor-or-self::*/gmd:date/gmd:CI_Date/gmd:date"/></dd>
+                                                </xsl:if>
+                                                <xsl:if test="contains(gmd:dateType/gmd:CI_DateTypeCode/@codeListValue,'creation')">
+                                                    <dt>Creation Date</dt>
+                                                    <dd><xsl:value-of select="ancestor-or-self::*/gmd:date/gmd:CI_Date/gmd:date"/></dd>
+                                                </xsl:if>
+                                                <xsl:if test="contains(gmd:dateType/gmd:CI_DateTypeCode/@codeListValue,'revision')">
+                                                    <dt>Revision Date</dt>
+                                                    <dd><xsl:value-of select="ancestor-or-self::*/gmd:date/gmd:CI_Date/gmd:date"/></dd>
+                                                </xsl:if>
+                                            </xsl:for-each>
+                                            <dt>Feature Catalog Identifier</dt>
+                                            <dd><xsl:value-of select="gmd:contentInfo/gmd:MD_FeatureCatalogueDescription/gmd:featureCatalogueCitation/gmd:CI_Citation/gmd:identifier/gmd:MD_Identifier/gmd:code"/></dd>
+                                        </dl>
+                                    </dd>
+                                </dl>
+                            </dd>
+                        </xsl:if>
+                        <xsl:if test="gmd:contentInfo/gmd:MD_ImageDescription">
+                            <dt>Content Type</dt>
+                            <dd>
+                                <xsl:value-of select="gmd:contentInfo/gmd:MD_ImageDescription/gmd:contentType/gmd:MD_CoverageContentTypeCode[@codeListValue]"/>
+                            </dd>
+                        </xsl:if>
+                    </dl>
+                </dd>
+              </div>
+            </xsl:if>     
+            <!-- Spatial Representation -->   
+            <xsl:if test="gmd:spatialRepresentationInfo">
+              <div id="iso-spatial-representation-info">
+                <dt>Spatial Representation Information</dt>
+                <dd>
+                    <dl>
+                        <xsl:choose>
+                            <xsl:when test="gmd:spatialRepresentationInfo/gmd:MD_VectorSpatialRepresentation">
+                                <dt>Vector</dt>
+                                <dd>
+                                    <dl>
+                                        <dt>Topology Level</dt>
+                                        <dd>
+                                            <xsl:value-of select="gmd:spatialRepresentationInfo/gmd:MD_VectorSpatialRepresentation/gmd:topologyLevel/gmd:MD_TopologyLevelCode[@codeListValue]"/>
+                                        </dd>
+                                        <dt>Vector Object Type</dt>
+                                        <dd>
+                                            <xsl:value-of select="gmd:spatialRepresentationInfo/gmd:MD_VectorSpatialRepresentation/gmd:geometricObjects/gmd:MD_GeometricObjects/gmd:geometricObjectType/gmd:MD_GeometricObjectTypeCode[@codeListValue]"/>
+                                        </dd>
+                                        <dt>Vector Object Count</dt>
+                                        <dd>
+                                            <xsl:value-of select="gmd:spatialRepresentationInfo/gmd:MD_VectorSpatialRepresentation/gmd:geometricObjects/gmd:MD_GeometricObjects/gmd:geometricObjectCount"/>
+                                        </dd>
+                                    </dl>     
+                                </dd>
+                            </xsl:when>
+                            
+                            <xsl:when test="gmd:spatialRepresentationInfo/gmd:MD_GridSpatialRepresentation">
+                                <dt>Raster</dt>
+                                <dd>
+                                    <dl>
+                                        <xsl:if test="gmd:spatialRepresentationInfo/gmd:MD_GridSpatialRepresentation/gmd:numberOfDimensions">
+                                            <dt>Number of Dimensions</dt>
+                                            <dd>
+                                                <xsl:value-of select="gmd:spatialRepresentationInfo/gmd:MD_GridSpatialRepresentation/gmd:numberOfDimensions"/>
+                                            </dd>
+                                        </xsl:if>
+                                        <dd>
+                                            <dl>
+                                        <xsl:for-each select="gmd:spatialRepresentationInfo/MD_GridSpatialRepresentation/gmd:axisDimensionProperties/gmd:MD_Dimension">
+                                            <xsl:if test="gmd:dimensionName/gmd:MD_DimensionNameTypeCode/@codeListValue='column'">
+                                                <dt>Column Count</dt>
+                                                <dd>
+                                                    <xsl:value-of select="gmd:dimensionSize"/>
+                                                </dd></xsl:if>
+                                            
+                                            <xsl:if test="gmd:dimensionName/gmd:MD_DimensionNameTypeCode/@codeListValue='row'">
+                                                <dt>Row Count</dt>
+                                                <dd>
+                                                    <xsl:value-of select="gmd:dimensionSize"/>
+                                                </dd></xsl:if>
+                                        </xsl:for-each>
+                                        
+                                        <xsl:if test="gmd:spatialRepresentationInfo/MD_GridSpatialRepresentation/gmd:cellGeometry/gmd:MD_CellGeometryCode">
+                                            <dt>Cell Geometry Type</dt>
+                                            <dd>
+                                                <xsl:value-of select="gmd:spatialRepresentationInfo/MD_GridSpatialRepresentation/gmd:cellGeometry/gmd:MD_CellGeometryCode/@codeListValue"/>
+                                            </dd>
+                                        </xsl:if>
+                                        
+                                        <xsl:if test="gmd:spatialRepresentationInfo/MD_GridSpatialRepresentation/gmd:cornerPoints">
+                                            <dt>Corner Points</dt>
+                                            <dd>
+                                                <dl>
+                                                    <xsl:for-each select="gmd:spatialRepresentationInfo/MD_GridSpatialRepresentation/gmd:cornerPoints/gml:Point">
+                                                        <dt>Point</dt>
+                                                        <dd><xsl:value-of select="gml:pos"/></dd>
+                                                    </xsl:for-each>
+                                                </dl>
+                                            </dd>
+                                            
+                                            <xsl:for-each select="gmd:spatialRepresentationInfo/MD_GridSpatialRepresentation/gmd:centerPoint/gml:Point">
+                                                <dt>Center Point</dt>
+                                                <dd><xsl:value-of select="gml:pos"/></dd>
+                                            </xsl:for-each>
+                                        </xsl:if>
+                                            </dl>
+                                        </dd>
+                                    </dl>     
+                                </dd>
+                            </xsl:when>
+                            <xsl:when test="gmd:spatialRepresentationInfo/gmd:MD_Georectified">
+                                <dt>Raster</dt>
+                                <dd>
+                                    <dl>
+                                        <xsl:if test="gmd:spatialRepresentationInfo/gmd:MD_Georectified/gmd:numberOfDimensions">
+                                            <dt>Number of Dimensions</dt>
+                                            <dd>
+                                                <xsl:value-of select="gmd:spatialRepresentationInfo/gmd:MD_Georectified/gmd:numberOfDimensions"/>
+                                            </dd>
+                                        </xsl:if>
+                                        
+                                       <xsl:for-each select="gmd:spatialRepresentationInfo/gmd:MD_Georectified/gmd:axisDimensionProperties/gmd:MD_Dimension">
+                                        <xsl:if test="gmd:dimensionName/gmd:MD_DimensionNameTypeCode/@codeListValue='column'">
+                                            <dt>Column Count</dt>
+                                              <dd>
+                                              <xsl:value-of select="gmd:dimensionSize"/>
+                                              </dd></xsl:if>
+    
+                                           <xsl:if test="gmd:dimensionName/gmd:MD_DimensionNameTypeCode/@codeListValue='row'">
+                                            <dt>Row Count</dt>
+                                            <dd>
+                                                <xsl:value-of select="gmd:dimensionSize"/>
+                                            </dd></xsl:if>
+                                        </xsl:for-each>
+                                        
+                                        <xsl:if test="gmd:spatialRepresentationInfo/gmd:MD_Georectified/gmd:cellGeometry/gmd:MD_CellGeometryCode">
+                                            <dt>Cell Geometry Type</dt>
+                                            <dd>
+                                                <xsl:value-of select="gmd:spatialRepresentationInfo/gmd:MD_Georectified/gmd:cellGeometry/gmd:MD_CellGeometryCode/@codeListValue"/>
+                                            </dd>
+                                        </xsl:if>
+                                        
+                                        <xsl:if test="gmd:spatialRepresentationInfo/gmd:MD_Georectified/gmd:cornerPoints">
+                                            <dt>Corner Points</dt>
+                                            <dd>
+                                                <dl>
+                                                    <xsl:for-each select="gmd:spatialRepresentationInfo/gmd:MD_Georectified/gmd:cornerPoints/gml:Point">
+                                                        <dt>Point</dt>
+                                                        <dd><xsl:value-of select="gml:pos"/></dd>
+                                                    </xsl:for-each>
+                                                </dl>
+                                            </dd>
+                                            
+                                            <xsl:for-each select="gmd:spatialRepresentationInfo/gmd:MD_Georectified/gmd:centerPoint/gml:Point">
+                                                <dt>Center Point</dt>
+                                                <dd><xsl:value-of select="gml:pos"/></dd>
+                                            </xsl:for-each>
+                                        </xsl:if>
+                                    </dl>     
+                                </dd>
+                            </xsl:when>
+                        </xsl:choose>
+                    </dl>
+                </dd>
+              </div>
+            </xsl:if>            
 
-  <xsl:template match="gmd:distributor">
-    <h4>Distributor:</h4>
-    <font>
-    <xsl:for-each select="gmd:MD_Distributor/gmd:distributorContact">
-      <p><b><i>Distributor Contact:</i></b></p>
-      <blockquote>
-      <xsl:call-template name="CI_ResponsibleParty">
-        <xsl:with-param name="element" select="gmd:CI_ResponsibleParty"/>          
-        <xsl:with-param name="italicize-heading" select="false()"/>  
-      </xsl:call-template> 
-      </blockquote>
-    </xsl:for-each>
-    <xsl:for-each select="gmd:MD_Distributor/gmd:distributionOrderProcess">
-      <p><b><i>Distribution Order Process:</i></b></p>
-      <blockquote>
-        <xsl:for-each select="gmd:MD_StandardOrderProcess">
-          <p><b>Standard Order Process:</b></p>
-          <blockquote>
-            <xsl:for-each select="gmd:fees">
-              <p><b>Fees: </b><xsl:value-of select="."/></p>
-            </xsl:for-each>
-          </blockquote> 
-        </xsl:for-each>
-      </blockquote>
-    </xsl:for-each>
-    <xsl:if test="string-length( gmd:MD_Distributor/gmd:distributorFormat )">
-      <p><b><i>Distributor Formats:</i></b></p>
-      <blockquote>
-        <xsl:apply-templates select="gmd:MD_Distributor/gmd:distributorFormat"/>
-      </blockquote>
-    </xsl:if>
-    <xsl:if test="string-length( gmd:MD_Distributor/gmd:distributorTransferOptions )">
-      <p><b><i>Distributor Transfer Options:</i></b></p>
-      <xsl:apply-templates select="gmd:MD_Distributor/gmd:distributorTransferOptions"/>
-    </xsl:if>
-    </font>
-  </xsl:template>
-
-  <xsl:template match="gmd:distributorFormat">
-    <b>Name: </b><xsl:value-of select="gmd:MD_Format/gmd:name"/><br/>
-    <xsl:choose>
-      <xsl:when test="string-length( gmd:MD_Format/gmd:version )">
-        <b>Version: </b><xsl:value-of select="gmd:MD_Format/gmd:version"/><br/>
-      </xsl:when>
-      <xsl:otherwise>
-        <b>Version: </b><xsl:value-of select="gmd:MD_Format/gmd:version/@gco:nilReason"/><br/>
-      </xsl:otherwise>
-    </xsl:choose>
-  </xsl:template>
-
-  <xsl:template match="gmd:distributorTransferOptions">
-    <xsl:call-template name="CI_OnlineResource">
-      <xsl:with-param name="element" select="gmd:MD_DigitalTransferOptions/gmd:onLine/gmd:CI_OnlineResource"/>
-    </xsl:call-template>
-  </xsl:template>
-
-  <xsl:template match="gmd:distributionFormat">
-    <h4>Distribution Format:</h4>
-    <font>
-    <xsl:for-each select="gmd:MD_Format">        
-      <p><b><i>Data File Format:</i></b></p>
-      <blockquote>            
-        <xsl:if test="string-length( gmd:name )">
-          <b>Name: </b><xsl:value-of select="gmd:name"/><br/>
-        </xsl:if>
-        <xsl:if test="string-length( gmd:version )">
-          <b>Version: </b><xsl:value-of select="gmd:version"/><br/>
-        </xsl:if>
-        <xsl:if test="string-length( gmd:specification )">
-          <b>Specification: </b><xsl:value-of select="gmd:specification"/><br/>
-        </xsl:if>
-      </blockquote>
-    </xsl:for-each>
-    </font>
-  </xsl:template>
-  
-  <xsl:template match="gmd:transferOptions">
-    <h4>Digital Transfer Options:</h4>                  
-    <xsl:for-each select="gmd:MD_DigitalTransferOptions">
-      <xsl:for-each select="gmd:transferSize">
-        <p><b><i>Transfer Size:</i></b> <xsl:value-of select="."/> MB</p>
-      </xsl:for-each>
-      <xsl:if test="gmd:onLine">
-        <p><b><i>Online Transfer Options:</i></b></p>
-      </xsl:if>
-      <xsl:for-each select="gmd:onLine">
-        <blockquote>
-          <p><b>Online Resource:</b></p>
-          <blockquote>
-            <xsl:for-each select="gmd:CI_OnlineResource">
-              <xsl:call-template name="CI_OnlineResource">
-                <xsl:with-param name="element" select="."/>
-              </xsl:call-template> 
-            </xsl:for-each>
-          </blockquote>
-        </blockquote>
-      </xsl:for-each>
-      <xsl:if test="gmd:offLine">
-        <p><b><i>Offline Transfer Options:</i></b></p>
-      </xsl:if>
-      <xsl:for-each select="gmd:offLine">
-        <blockquote>
-          <p><b>Offline Resource:</b></p>
-          <blockquote>
-            <xsl:for-each select="gmd:MD_Medium">        
-              <p>
-                <xsl:if test="string-length( gmd:name )">
-                  <b>Name: </b><xsl:value-of select="gmd:name"/> (<a href="http://pacioos.org/metadata/gmxCodelists.html#MD_MediumNameCode">MD_MediumNameCode</a>)<br/>
+      <!-- Metadata Reference Info -->
+        <div id="iso-metadata-reference-info">
+          <dt>Metadata Reference Information</dt>    
+            <dd>
+              <dl>      
+                <dt>Hierarchy Level</dt>
+                <dd>
+                  <xsl:value-of select="gmd:hierarchyLevelName"/>
+                </dd>    
+                <dt>Metadata File Identifier</dt>
+                <dd>
+                  <xsl:value-of select="gmd:fileIdentifier"/>
+                </dd>       
+                <xsl:if test="gmd:parentIdentifier">
+                  <dt>Parent Identifier</dt>
+                  <dd>
+                    <xsl:value-of select="gmd:parentIdentifier"/>
+                  </dd>  
                 </xsl:if>
-                <xsl:apply-templates select="name"/>          
-                <xsl:if test="string-length( gmd:density )">
-                  <b>Density: </b><xsl:value-of select="gmd:density"/><br/>
+                <xsl:if test="gmd:dataSetURI">
+                  <dt>Dataset URI</dt>
+                  <dd>
+                    <xsl:value-of select="gmd:dataSetURI"/>
+                  </dd> 
+                </xsl:if>  
+                <xsl:for-each select="gmd:metadataMaintenance/gmd:MD_MaintenanceInformation/gmd:contact">            
+                  <dt>Metadata Point of Contact</dt>             
+                  <dd>
+                    <dl>
+                      <xsl:for-each select="gmd:CI_ResponsibleParty">
+                        <dt>Name</dt>
+                        <dd>
+                          <xsl:value-of select="gmd:organisationName | gmd:individualName"/>
+                        </dd>
+                        <xsl:if test="gmd:positionName">
+                          <dt>Position Name</dt>
+                          <dd>
+                            <xsl:value-of select="gmd:positionName"/>
+                          </dd>  
+                        </xsl:if>
+                        <xsl:if test="gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:deliveryPoint">
+                          <dt>Delivery Point</dt>
+                          <dd>
+                            <xsl:value-of select="gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:deliveryPoint"/>
+                          </dd>
+                        </xsl:if>   
+                        <xsl:if test="gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:city">
+                          <dt>City</dt>
+                          <dd>
+                            <xsl:value-of select="gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:city"/>
+                          </dd>
+                        </xsl:if>  
+                        <xsl:if test="gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:administrativeArea">
+                          <dt>Administrative Area</dt>
+                          <dd>
+                            <xsl:value-of select="gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:administrativeArea"/>
+                          </dd>
+                        </xsl:if>
+                        <xsl:if test="gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:postalCode">
+                          <dt>Postal Code</dt>
+                          <dd>
+                            <xsl:value-of select="gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:postalCode"/>
+                          </dd>
+                        </xsl:if>
+                        <xsl:if test="gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:country">
+                          <dt>Country</dt>
+                          <dd>
+                            <xsl:value-of select="gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:country"/>
+                          </dd>
+                        </xsl:if>
+                        <xsl:if test="gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:electronicMailAddress">
+                          <dt>Email</dt>
+                          <dd>
+                            <xsl:value-of select="gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:electronicMailAddress"/>
+                          </dd>
+                        </xsl:if>
+                        <xsl:if test="gmd:contactInfo/gmd:CI_Contact/gmd:phone/gmd:CI_Telephone/gmd:voice">
+                          <dt>Phone</dt>
+                          <dd>
+                            <xsl:value-of select="gmd:contactInfo/gmd:CI_Contact/gmd:phone/gmd:CI_Telephone/gmd:voice"/>
+                          </dd>
+                        </xsl:if>    
+                      </xsl:for-each>
+                    </dl>
+                  </dd>
+                </xsl:for-each>
+                <dt>Metadata Date Stamp</dt>
+                <dd>
+                  <xsl:value-of select="gmd:dateStamp"/>
+                </dd>
+                <dt>Metadata Standard Name</dt>     
+                <dd>
+                  <xsl:value-of select="gmd:metadataStandardName"/>
+                </dd>
+                <dt>Metadata Standard Version</dt>
+                <dd>
+                  <xsl:value-of select="gmd:metadataStandardVersion"/>
+                </dd>    
+                <xsl:if test="gmd:characterSet/gmd:MD_CharacterSetCode[@codeListValue]/text()">
+                  <dt>Character Set</dt>
+                  <dd>
+                    <xsl:value-of select="gmd:characterSet/gmd:MD_CharacterSetCode[@codeListValue]"/>
+                  </dd>  
                 </xsl:if>
-                <xsl:if test="string-length( gmd:densityUnits )">
-                  <b>Density Units: </b><xsl:value-of select="gmd:densityUnits"/><br/>
-                </xsl:if>
-                <xsl:if test="string-length( gmd:mediumName )">
-                  <b>Medium Name: </b><xsl:value-of select="gmd:mediumName"/><br/>
-                </xsl:if>          
-                <xsl:if test="string-length( gmd:mediumFormat )">
-                  <b>Medium Format: </b><xsl:value-of select="gmd:mediumFormat"/> (<a href="http://pacioos.org/metadata/gmxCodelists.html#MD_MediumFormatCode">MD_MediumFormatCode</a>)<br/>
-                </xsl:if>
-              </p>
-            </xsl:for-each>
-          </blockquote>
-        </blockquote>
-      </xsl:for-each>
-    </xsl:for-each>
-  </xsl:template>
-
-  <!-- ACQUISITION_INFORMATION: *********************************************-->
-
-  <xsl:template match="gmd:acquisitionInformation/gmd:MI_AcquisitionInformation">
-    <hr/> 
-    <h3><a name="Acquisition_Information"></a>Acquisition Information:</h3>
-    <xsl:apply-templates select="gmd:instrument"/>
-    <xsl:apply-templates select="gmd:platform"/>
-    <p><a href="javascript:void(0)" onClick="window.scrollTo( 0, 0 ); this.blur(); return false;">Back to Top</a></p>
-  </xsl:template>
-
-  <xsl:template match="gmd:instrument">
-    <h4>Instrument Information:</h4>    
-    <font>
-    <xsl:for-each select="gmd:MI_Instrument">
-      <p><b><i>Instrument:</i></b></p>
-      <blockquote>
-        <xsl:for-each select="gmd:identifier">
-          <b>Identifier: </b><xsl:value-of select="."/><br/>
-        </xsl:for-each>
-        <xsl:for-each select="gmd:type">
-          <b>Type: </b><xsl:value-of select="."/><br/>
-        </xsl:for-each>
-      </blockquote>
-    </xsl:for-each>
-    </font>
-  </xsl:template>
-   
-  <xsl:template match="gmd:platform"> 
-    <h4>Platform Information:</h4>
-    <font>
-    <xsl:for-each select="gmd:MI_Platform">
-      <p><b><i>Platform:</i></b></p>
-      <blockquote>
-        <xsl:for-each select="gmd:identifier">
-          <b>Identifier: </b><xsl:value-of select="."/><br/>
-        </xsl:for-each>
-        <xsl:for-each select="gmd:description">
-          <b>Description: </b><xsl:value-of select="."/><br/>
-        </xsl:for-each>
-        <xsl:for-each select="gmd:instrument">
-          <b>Instrument: </b><xsl:value-of select="."/><br/>
-        </xsl:for-each>
-      </blockquote>
-    </xsl:for-each>    
-    </font>
-  </xsl:template>
-
-  <!-- NAMED TEMPLATES: *****************************************************-->
-
-  <!-- template: CI_Citation ************************************************-->
-
-  <xsl:template name="CI_Citation">
-    <xsl:param name="element"/>
-    <xsl:param name="italicize-heading"/>    
-    <xsl:param name="wrap-text"/>
-    <xsl:choose>
-      <xsl:when test="$italicize-heading">
-        <p><b><i>Citation Information:</i></b></p>
-      </xsl:when>
-      <xsl:otherwise>
-        <p><b>Citation Information:</b></p>
-      </xsl:otherwise>
-    </xsl:choose>
-    <blockquote>    
-      <xsl:for-each select="$element/gmd:title">
-        <xsl:choose>
-          <xsl:when test="$wrap-text">
-            <div style="margin-right: 185px;"><b>Title: </b><xsl:value-of select="."/></div>
-          </xsl:when>
-          <xsl:otherwise>
-            <b>Title: </b><xsl:value-of select="."/><br/>
-          </xsl:otherwise>
-        </xsl:choose>
-      </xsl:for-each>
-      <xsl:for-each select="$element/gmd:alternateTitle">
-        <b>Alternate Title: </b><xsl:value-of select="."/><br/>
-      </xsl:for-each>
-      <xsl:for-each select="$element/gmd:date">
-        <xsl:call-template name="CI_Date">
-          <xsl:with-param name="element" select="./gmd:CI_Date"/>          
-        </xsl:call-template>        
-      </xsl:for-each>      
-      <xsl:for-each select="$element/gmd:edition">
-        <b>Edition: </b><xsl:value-of select="."/><br/>        
-      </xsl:for-each>      
-      <xsl:for-each select="$element/gmd:editionDate">
-        <b>Edition Date: </b>
-        <xsl:call-template name="date">
-          <xsl:with-param name="element" select="."/>
-        </xsl:call-template>
-        <br/>
-      </xsl:for-each>
-      <xsl:for-each select="$element/gmd:identifier">
-        <b>Identifier:</b><br/>
-        <blockquote>
-          <xsl:if test="gmd:MD_Identifier/gmd:code">
-            <b>Code: </b><xsl:value-of select="gmd:MD_Identifier/gmd:code"/><br/>
-          </xsl:if>
-          <xsl:if test="gmd:MD_Identifier/gmd:authority">
-            <b>Authority: </b><xsl:value-of select="gmd:MD_Identifier/gmd:authority"/><br/>
-          </xsl:if>
-        </blockquote>
-      </xsl:for-each>
-      <xsl:for-each select="$element/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty">
-        <xsl:call-template name="CI_ResponsibleParty">
-          <xsl:with-param name="element" select="."/>
-          <xsl:with-param name="italicize-heading" select="false()"/>          
-        </xsl:call-template>        
-      </xsl:for-each>
-      <xsl:for-each select="$element/gmd:presentationForm">        
-        <b>Presentation Form: </b> <xsl:value-of select="."/> (<a href="http://pacioos.org/metadata/gmxCodelists.html#CI_PresentationFormCode" target="_blank">CI_PresentationFormCode</a>)<br/>
-      </xsl:for-each>      
-      <xsl:for-each select="$element/gmd:series">        
-        <b>Series: </b><xsl:value-of select="."/><br/> 
-      </xsl:for-each>      
-      <xsl:for-each select="$element/gmd:otherCitationDetails">
-        <b>Other Citation Details: </b><xsl:value-of select="."/><br/>        
-      </xsl:for-each>
-    </blockquote>
-  </xsl:template>
-
-  <!-- template: CI_Date ****************************************************-->
-
-  <xsl:template name="CI_Date">
-    <xsl:param name="element"/>
-    <xsl:if test="string-length( $element/gmd:date ) and $element/gmd:dateType/gmd:CI_DateTypeCode != 'issued' and $element/gmd:dateType/gmd:CI_DateTypeCode != 'revision'">
-      <p><b>Date:</b></p>
-      <blockquote>
-        <b>Date: </b>
-        <xsl:call-template name="date">
-          <xsl:with-param name="element" select="$element/gmd:date/gco:Date"/>
-        </xsl:call-template>
-        <br/>
-        <xsl:if test="string-length( $element/gmd:dateType/gmd:CI_DateTypeCode )">
-          <b>Date Type: </b><xsl:value-of select="$element/gmd:dateType"/> (<a href="http://pacioos.org/metadata/gmxCodelists.html#CI_DateTypeCode">CI_DateTypeCode</a>)<br/>
-        </xsl:if>
-      </blockquote>
-    </xsl:if>
-  </xsl:template>
-
-  <!-- template: CI_ResponsibleParty ****************************************-->
-
-  <xsl:template name="CI_ResponsibleParty">
-    <xsl:param name="element"/>
-    <xsl:param name="italicize-heading"/>        
-    <xsl:choose>
-      <xsl:when test="$italicize-heading">
-        <p><b><i>Responsible Party:</i></b></p>
-      </xsl:when>
-      <xsl:otherwise>
-        <p><b>Responsible Party:</b></p>
-      </xsl:otherwise>
-    </xsl:choose>
-    <blockquote>
-      <div>
-      <xsl:for-each select="$element/gmd:individualName">
-        <b>Individual Name: </b><xsl:value-of select="."/><br/>
-      </xsl:for-each>
-      <xsl:for-each select="$element/gmd:organisationName">
-        <xsl:if test="string-length( . )">
-          <b>Organization Name: </b><xsl:value-of select="$element/gmd:organisationName"/><br/>
-        </xsl:if>
-      </xsl:for-each>
-      <xsl:for-each select="$element/gmd:positionName">
-        <xsl:if test=". != 'none'">
-          <b>Position Name: </b><xsl:value-of select="."/><br/>
-        </xsl:if>
-      </xsl:for-each>
-      <xsl:for-each select="$element/gmd:contactInfo/gmd:CI_Contact">
-        <xsl:if test="string-length( . )">
-          <xsl:call-template name="CI_Contact">
-            <xsl:with-param name="element" select="."/>
-          </xsl:call-template>
-        </xsl:if>
-      </xsl:for-each>
-      <xsl:for-each select="$element/gmd:role">
-        <xsl:if test="string-length( ./gmd:CI_RoleCode )">
-          <b>Contact Role: </b><xsl:value-of select="."/> (<a href="http://pacioos.org/metadata/gmxCodelists.html#CI_RoleCode" target="_blank">CI_RoleCode</a>)<br/>
-        </xsl:if>
-      </xsl:for-each>
-      </div>
-    </blockquote>
-  </xsl:template>
-
-  <!-- template: CI_Contact *************************************************-->
-
-  <xsl:template name="CI_Contact">
-    <xsl:param name="element"/> 
-    <b>Contact: </b>
-    <xsl:for-each select="$element/gmd:phone/gmd:CI_Telephone">
-      <xsl:call-template name="CI_Telephone">
-        <xsl:with-param name="element" select="."/>
-      </xsl:call-template>
-    </xsl:for-each>
-    <xsl:for-each select="$element/gmd:address/gmd:CI_Address">
-      <xsl:call-template name="CI_Address">
-        <xsl:with-param name="element" select="."/>
-      </xsl:call-template>
-    </xsl:for-each>
-    <xsl:for-each select="$element/gmd:onlineResource/gmd:CI_OnlineResource">
-      <xsl:call-template name="CI_OnlineResource">
-        <xsl:with-param name="element" select="."/>
-      </xsl:call-template>
-    </xsl:for-each>
-  </xsl:template>
-
-  <!-- template: CI_Telephone ***********************************************-->
-
-  <xsl:template name="CI_Telephone">
-    <xsl:param name="element"/>
-    <blockquote>
-      <p><b>Contact Phone: </b></p>
-      <blockquote>
-        <xsl:for-each select="$element/gmd:voice">
-          <xsl:if test="string-length( . )">
-            <b>Contact Voice Telephone: </b><xsl:value-of select="."/><br/>
-          </xsl:if>        
-        </xsl:for-each>        
-        <xsl:for-each select="$element/gmd:facsimile">
-          <xsl:if test="string-length( . )">
-            <b>Contact Facsimile Telephone: </b><xsl:value-of select="."/><br/>
-          </xsl:if>        
-        </xsl:for-each>       
-      </blockquote>    
-    </blockquote>
-  </xsl:template>
-
-  <!-- template: CI_Address *************************************************-->
-
-  <xsl:template name="CI_Address">
-    <xsl:param name="element"/>
-    <blockquote>
-      <p><b>Contact Address: </b></p>
-      <blockquote>
-        <xsl:if test="string-length( $element/gmd:deliveryPoint )">
-          <b>Delivery Point: </b><xsl:value-of select="$element/gmd:deliveryPoint"/><br/>
-        </xsl:if>
-        <xsl:if test="string-length( $element/gmd:city )">
-          <b>City: </b><xsl:value-of select="$element/gmd:city"/><br/>
-        </xsl:if>
-        <xsl:if test="string-length( $element/gmd:administrativeArea )">
-          <b>Administrative Area: </b><xsl:value-of select="$element/gmd:administrativeArea"/><br/>
-        </xsl:if>
-        <xsl:if test="string-length( $element/gmd:postalCode )">
-          <b>Postal Code: </b><xsl:value-of select="$element/gmd:postalCode"/><br/>
-        </xsl:if>
-        <xsl:if test="string-length( $element/gmd:country )">
-          <b>Country: </b><xsl:value-of select="$element/gmd:country"/><br/>
-        </xsl:if>
-        <xsl:if test="string-length( $element/gmd:electronicMailAddress )">
-          <b>Email: </b><a href="mailto:{$element/gmd:electronicMailAddress/gco:CharacterString}"><xsl:value-of select="$element/gmd:electronicMailAddress"/></a><br/>        
-        </xsl:if>
-      </blockquote>
-    </blockquote>    
-  </xsl:template>
-
-  <!-- template: CI_OnlineResource ******************************************-->
-
-  <xsl:template name="CI_OnlineResource">
-    <xsl:param name="element"/>
-    <xsl:if test="string-length( $element/gmd:linkage )">
-      <blockquote>
-        <p><b>Online Resource:</b></p>
-        <blockquote>
-          <xsl:choose>
-            <xsl:when test="$element/gmd:linkage != 'Unknown'">
-              <xsl:variable name="url">
-                <!-- Replace PacIOOS internal URL with external proxy: -->
-                <xsl:call-template name="replace-string">
-                  <xsl:with-param name="element" select="$element/gmd:linkage/gmd:URL"/>
-                  <xsl:with-param name="old-string">lawelawe.soest.hawaii.edu:8080</xsl:with-param>
-                  <xsl:with-param name="new-string">oos.soest.hawaii.edu</xsl:with-param>
-                </xsl:call-template>
-              </xsl:variable>
-              <span style="float: left; margin-right: 4px;"><b>Linkage: </b></span><a href="{$url}"><div class="wrapline"><xsl:value-of select="$url"/></div></a>
-            </xsl:when>
-            <xsl:otherwise>
-              <b>Linkage: </b><xsl:value-of select="$element/gmd:linkage"/><br/>
-            </xsl:otherwise>        
-          </xsl:choose>     
-          <xsl:if test="string-length( $element/gmd:name/gco:CharacterString )">
-            <b>Name: </b><xsl:value-of select="$element/gmd:name"/><br/>
-          </xsl:if>
-          <xsl:if test="string-length( $element/gmd:description/gco:CharacterString )">
-            <b>Description: </b><xsl:value-of select="$element/gmd:description"/><br/>
-          </xsl:if>
-          <xsl:if test="string-length( $element/gmd:function )">
-            <xsl:variable name="codeList" select="substring-after( $element/gmd:function/gmd:CI_OnLineFunctionCode/@codeList, '#' )"/>
-            <xsl:variable name="codeListShortName">
-              <xsl:choose>
-                <xsl:when test="contains( $codeList, ':' )">
-                  <xsl:value-of select="substring-after( $codeList, ':' )"/>
-                </xsl:when>
-                <xsl:otherwise>
-                  <xsl:value-of select="$codeList"/>
-                </xsl:otherwise>
-              </xsl:choose>
-            </xsl:variable>
-            <b>Function: </b><xsl:value-of select="$element/gmd:function"/> (<a href="http://pacioos.org/metadata/gmxCodelists.html#{$codeListShortName}"><xsl:value-of select="$codeListShortName"/></a>)<br/>
-          </xsl:if> 
-        </blockquote>
-      </blockquote>    
-    </xsl:if>
-  </xsl:template>
-
-  <!-- template: MD_TaxonCl (recursive) *************************************-->
-
-  <xsl:template match="gmd:taxonCl/gmd:MD_TaxonCl">
-    <div style="margin-left: 15px;">
-      <xsl:choose>
-        <xsl:when test="string-length( gmd:taxonrv )"> 
-          <b><xsl:value-of select="gmd:taxonrn/gco:CharacterString"/>: </b><xsl:value-of select="gmd:taxonrv"/>
-        </xsl:when>
-        <xsl:otherwise>
-          <b><xsl:value-of select="gmd:taxonrn/gco:CharacterString"/>: </b><xsl:value-of select="gmd:taxonrv/@gco:nilReason"/>
-        </xsl:otherwise>
-      </xsl:choose>
-      <xsl:for-each select="gmd:common">
-        <div style="margin-left: 15px;"><b>Common Name: </b><xsl:value-of select="." /></div>
-      </xsl:for-each>
-      <xsl:apply-templates select="gmd:taxonCl/gmd:MD_TaxonCl" />
-    </div>  
-  </xsl:template>
-
-  <!-- template: date *******************************************************-->
-
-  <xsl:template name="date">
-    <xsl:param name="element"/>
-    <xsl:choose>
-      <xsl:when test="contains( $element, 'known' )">
-        <xsl:value-of select="$element"/>
-      </xsl:when>
-      <xsl:otherwise>
-        <xsl:variable name="year" select="substring($element, 1, 4)"/>
-        <xsl:variable name="month" select="substring($element, 6, 2)"/>
-        <xsl:variable name="day" select="substring($element, 9, 2)"/>
-        <xsl:if test="$month = '01'">
-          <xsl:text>January </xsl:text>
-        </xsl:if>
-        <xsl:if test="$month = '02'">
-          <xsl:text>February </xsl:text>
-        </xsl:if>
-        <xsl:if test="$month = '03'">
-          <xsl:text>March </xsl:text>
-        </xsl:if>
-        <xsl:if test="$month = '04'">
-          <xsl:text>April </xsl:text>
-        </xsl:if>
-        <xsl:if test="$month = '05'">
-          <xsl:text>May </xsl:text>
-        </xsl:if>
-        <xsl:if test="$month = '06'">
-          <xsl:text>June </xsl:text>
-        </xsl:if>
-        <xsl:if test="$month = '07'">
-          <xsl:text>July </xsl:text>
-        </xsl:if>
-        <xsl:if test="$month = '08'">
-          <xsl:text>August </xsl:text>
-        </xsl:if>
-        <xsl:if test="$month = '09'">
-          <xsl:text>September </xsl:text>
-        </xsl:if>
-        <xsl:if test="$month = '10'">
-          <xsl:text>October </xsl:text>
-        </xsl:if>
-        <xsl:if test="$month = '11'">
-          <xsl:text>November </xsl:text>
-        </xsl:if>
-        <xsl:if test="$month = '12'">
-          <xsl:text>December </xsl:text>
-        </xsl:if>
-        <xsl:if test="string-length( $day )">
-          <xsl:choose>
-            <xsl:when test="$day = '01'">
-              <xsl:variable name="daydisplay" select="'1'"/>
-              <xsl:value-of select="$daydisplay"/><xsl:text>, </xsl:text>
-            </xsl:when>
-            <xsl:when test="$day = '02'">
-              <xsl:variable name="daydisplay" select="'2'"/>
-              <xsl:value-of select="$daydisplay"/><xsl:text>, </xsl:text>
-            </xsl:when>
-            <xsl:when test="$day = '03'">
-              <xsl:variable name="daydisplay" select="'3'"/>
-              <xsl:value-of select="$daydisplay"/><xsl:text>, </xsl:text>
-            </xsl:when>
-            <xsl:when test="$day = '04'">
-              <xsl:variable name="daydisplay" select="'4'"/>
-              <xsl:value-of select="$daydisplay"/><xsl:text>, </xsl:text>
-            </xsl:when>
-            <xsl:when test="$day = '05'">
-              <xsl:variable name="daydisplay" select="'5'"/>
-              <xsl:value-of select="$daydisplay"/><xsl:text>, </xsl:text>
-            </xsl:when>
-            <xsl:when test="$day = '06'">
-              <xsl:variable name="daydisplay" select="'6'"/>
-              <xsl:value-of select="$daydisplay"/><xsl:text>, </xsl:text>
-            </xsl:when>
-            <xsl:when test="$day = '07'">
-              <xsl:variable name="daydisplay" select="'7'"/>
-              <xsl:value-of select="$daydisplay"/><xsl:text>, </xsl:text>
-            </xsl:when>
-            <xsl:when test="$day = '08'">
-              <xsl:variable name="daydisplay" select="'8'"/>
-              <xsl:value-of select="$daydisplay"/><xsl:text>, </xsl:text>
-            </xsl:when>
-            <xsl:when test="$day = '09'">
-              <xsl:variable name="daydisplay" select="'9'"/>
-              <xsl:value-of select="$daydisplay"/><xsl:text>, </xsl:text>
-            </xsl:when>
-            <xsl:otherwise>
-              <xsl:value-of select="$day"/><xsl:text>, </xsl:text>
-            </xsl:otherwise>
-          </xsl:choose>
-        </xsl:if>
-        <xsl:value-of select="$year"/>
-      </xsl:otherwise>
-    </xsl:choose>
-  </xsl:template>
-
+              </dl>
+            </dd>  
+          </dl>
+        </div>
+     </xsl:template> 
 </xsl:stylesheet>

--- a/spec/features/iso2html_spec.rb
+++ b/spec/features/iso2html_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+
+#TODO Provide additional expectations on html structure
+describe 'ISO 19139 to html' do
+  include XmlDocs
+  let(:page) { GeoCombine::Iso19139.new(stanford_iso).to_html }
+  describe 'Identification Information' do
+    it 'has sections' do
+      expect(page).to have_tag '#iso-identification-info' do
+        with_tag 'dt', text: /Citation/
+        with_tag 'dt', text: /Title/
+        with_tag 'dd', text: /Hydrologic Sub-Area Boundaries: Russian River Watershed, California, 1999/
+        with_tag 'dt', text: /Originator/
+        with_tag 'dd', text: trim('Circuit Rider Productions'), count: 4
+        with_tag 'dt', text: /Place of Publication/
+        with_tag 'dd', text: /Windsor/
+      end
+    end
+  end
+  describe 'Spatial Reference Information' do
+    it 'has sections' do
+      expect(page).to have_tag '#iso-spatial-reference-info'
+    end
+  end
+  describe 'Data Quality Information' do
+    it 'has sections' do
+      expect(page).to have_tag '#iso-data-quality-info'
+    end
+  end
+  describe 'Distribution Information' do
+    it 'has sections' do
+      expect(page).to have_tag '#iso-distribution-info'
+    end
+  end
+  describe 'Content Information' do
+    it 'has sections' do
+      expect(page).to have_tag '#iso-distribution-info'
+    end
+  end
+  describe 'Spatial Representation Information' do
+    it 'has sections' do
+      expect(page).to have_tag '#iso-spatial-representation-info'
+    end
+  end
+  describe 'Metadata Reference Information' do
+    it 'has sections' do
+      expect(page).to have_tag '#iso-metadata-reference-info'
+    end
+  end
+end

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -10,4 +10,8 @@ module Helpers
       return false
     end
   end
+
+  def trim(text)
+    %r/\A\s+#{text}\s+\Z/
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,9 +23,11 @@ require 'geo_combine'
 require 'fixtures/xml_docs'
 require 'fixtures/json_docs'
 require 'helpers'
+require 'rspec-html-matchers'
 
 RSpec.configure do |config|
   config.include Helpers
+  config.include RSpecHtmlMatchers
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
   # assertions if you prefer.


### PR DESCRIPTION
A big thanks to @kimdurante for the work she did on `iso2html.xsl`. Will need to add enhanced testing with a new static html Capybara driver.

Partially addresses #18 