### PR TITLE
adds support for Esri OpenData portal metadata conversion to GeoBlack…

### DIFF
--- a/geo_combine.gemspec
+++ b/geo_combine.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rsolr'
   spec.add_dependency 'nokogiri'
   spec.add_dependency 'json-schema'
+  spec.add_dependency 'sanitize'
 
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/lib/geo_combine.rb
+++ b/lib/geo_combine.rb
@@ -1,6 +1,7 @@
 require 'nokogiri'
 require 'json'
 require 'json-schema'
+require 'sanitize'
 
 module GeoCombine
 
@@ -47,10 +48,19 @@ module GeoCombine
   end
 end
 
+# Require translation mixins
 require 'geo_combine/formats'
 require 'geo_combine/subjects'
+require 'geo_combine/geometry_types'
 
+# Require helper mixins
+require 'geo_combine/formatting'
+
+# Require additional classes
 require 'geo_combine/fgdc'
 require 'geo_combine/geoblacklight'
 require 'geo_combine/iso19139'
+require 'geo_combine/esri_open_data'
+
+# Require gem files
 require 'geo_combine/version'

--- a/lib/geo_combine/esri_open_data.rb
+++ b/lib/geo_combine/esri_open_data.rb
@@ -1,0 +1,97 @@
+module GeoCombine
+  # Data model for ESRI's open data portal metadata
+  class EsriOpenData
+    include GeoCombine::Formatting
+    attr_reader :metadata
+
+    ##
+    # Initializes an EsriOpenData object for parsing
+    # @param [String] metadata a valid serialized JSON string from an ESRI Open
+    # Data portal
+    def initialize(metadata)
+      @metadata = JSON.parse(metadata)
+      @geometry = @metadata['extent']['coordinates']
+    end
+
+    ##
+    # Creates and returns a Geoblacklight schema object from this metadata
+    # @return [GeoCombine::Geoblacklight]
+    def to_geoblacklight
+      GeoCombine::Geoblacklight.new(geoblacklight_terms.to_json)
+    end
+
+    ##
+    # Builds a Geoblacklight Schema type hash from Esri Open Data portal
+    # metadata
+    # @return [Hash]
+    def geoblacklight_terms
+      {
+        uuid: @metadata['id'],
+        dc_identifier_s: @metadata['id'],
+        dc_title_s: @metadata['name'],
+        dc_description_s: sanitize_and_remove_lines(@metadata['description']),
+        dc_rights_s: 'Public',
+        dct_provenance_s: @metadata['owner'],
+        dct_references_s: references,
+        georss_box_s: georss_box,
+        # layer_id_s is used for describing a layer id for a web serivce (WMS, WFS) but is still a required field
+        layer_id_s: '',
+        layer_geom_type_s: @metadata['geometry_type'],
+        layer_modified_dt: @metadata['updated_at'],
+        layer_slug_s: @metadata['id'],
+        solr_geom: envelope,
+        # solr_year_i: '', No equivalent in Esri Open Data metadata
+        dc_subject_sm: @metadata['tags']
+      }
+    end
+
+    ##
+    # Converts references to json
+    # @return [String]
+    def references
+      references_hash.to_json
+    end
+
+    ##
+    # Builds references used for dct_references
+    # @return [Hash]
+    def references_hash
+      {
+        'http://schema.org/url' => @metadata['arcgis_online_item_url'],
+        'http://resources.arcgis.com/en/help/arcgis-rest-api' => @metadata['url']
+      }
+    end
+
+    ##
+    # Builds a GeoRSS box
+    # @return [String]
+    def georss_box
+      "#{south} #{west} #{north} #{east}"
+    end
+
+    ##
+    # Builds a Solr Envelope using CQL syntax
+    # @return [String]
+    def envelope
+      "ENVELOPE(#{west}, #{east}, #{north}, #{south})"
+    end
+
+    private
+
+    def north
+      @geometry[1][1]
+    end
+
+    def south
+      @geometry[0][1]
+    end
+
+    def east
+      @geometry[1][0]
+    end
+
+    def west
+      @geometry[0][0]
+    end
+  end
+end

--- a/lib/geo_combine/formatting.rb
+++ b/lib/geo_combine/formatting.rb
@@ -1,0 +1,29 @@
+module GeoCombine
+  ##
+  # Mixin used for formatting metadata fields
+  module Formatting
+    ##
+    # Sanitizes html from a text input
+    # @param [String] text
+    # @return [String]
+    def sanitize(text)
+      Sanitize.fragment(text)
+    end
+
+    ##
+    # Removes line breaks from a text input
+    # @param [String] text
+    # @return [String]
+    def remove_lines(text)
+      text.gsub(/\n/, '')
+    end
+
+    ##
+    # Sanitizes and removes lines from a text block
+    # @param [String] text
+    # @return [String]
+    def sanitize_and_remove_lines(text)
+      remove_lines(sanitize(text))
+    end
+  end
+end

--- a/lib/geo_combine/geometry_types.rb
+++ b/lib/geo_combine/geometry_types.rb
@@ -1,0 +1,11 @@
+module GeoCombine
+  module GeometryTypes
+    def geometry_types
+      {
+        'esriGeometryPoint' => 'Point',
+        'esriGeometryPolygon' => 'Polygon',
+        'esriGeometryPolyline' => 'Line'
+      }
+    end
+  end
+end

--- a/spec/fixtures/docs/esri_open_data.json
+++ b/spec/fixtures/docs/esri_open_data.json
@@ -1,0 +1,53 @@
+{
+  "object_id_field": null,
+  "supported_extensions": "",
+  "advanced_query_capabilities": {
+    "use_standardized_queries": true,
+    "supports_statistics": true,
+    "supports_order_by": true,
+    "supports_distinct": true,
+    "supports_pagination": true,
+    "supports_true_curve": true,
+    "supports_returning_query_extent": true,
+    "supports_query_with_distance": true
+  },
+  "supports_advanced_queries": true,
+  "display_field": "ETC_STATUS.ETC_CODE",
+  "max_record_count": 1000,
+  "record_count": 50,
+  "geometry_type": "esriGeometryPoint",
+  "arcgis_online_item_url": "https://www.arcgis.com/home/item.html?id=267b6c8cdee749bf90bb2737d9e07fc8",
+  "description": "\u003cspan style='color: rgb(77, 77, 77); font-family: ;'\u003eEbola Treatment Centers (ETCs)\u003c/span\u003e\u003cdiv\u003e\u003cspan style='color: rgb(77, 77, 77); font-family: ;'\u003e\u003cbr /\u003e\u003c/span\u003e\u003c/div\u003e\u003cdiv\u003e\u003cspan style='color: rgb(77, 77, 77); font-family: ;'\u003e\u003cbr /\u003e\u003c/span\u003e\u003c/div\u003e\u003cdiv\u003e\u003cspan style='color: rgb(77, 77, 77); font-family: ;'\u003e\u003cbr /\u003e\u003c/span\u003e\u003c/div\u003e\u003cdiv\u003e\u003cspan style='color: rgb(77, 77, 77); font-family: ;'\u003e\u003cbr /\u003e\u003c/span\u003e\u003c/div\u003e\u003cdiv\u003e\u003cp style='margin: 0cm 0cm 6pt; mso-add-space: auto;'\u003e\u003cfont face='Calibri, sans-serif' size='4'\u003e\u003cspan style='line-height: 22.15px;'\u003e\u003cb\u003e\u003cu\u003eAttribute Information\u003c/u\u003e\u003c/b\u003e\u003c/span\u003e\u003c/font\u003e\u003c/p\u003e\u003cp\u003e\u003cb\u003eAdmin2:\u003c/b\u003e\u003cbr /\u003e\r\n   Guinea – Prefecture\u003cbr /\u003e   Liberia – County\u003cbr /\u003e\u003cspan style='line-height: 1.3846;'\u003e   Sierra Leone – District\u003c/span\u003e\u003c/p\u003e\u003cp\u003e\u003cb\u003eCountryISO:\u003c/b\u003e 3-character ISO Country Code\u003c/p\u003e\u003cp\u003e\u003cb\u003eETC Code:\u003c/b\u003e Unique code\u003c/p\u003e\u003cp\u003e\u003cb\u003eSiteName:\u003c/b\u003e ETC Site Name\u003c/p\u003e\u003cp style='margin: 0cm 0cm 6pt; mso-add-space: auto;'\u003e\r\n\r\n\r\n\r\n\r\n\r\n\u003c/p\u003e\u003cp\u003e\u003cb\u003eStatus: \u003c/b\u003e\u003ci\u003e\u003cspan style='background: white; color: rgb(4, 4, 4); mso-ascii-font-family: Calibri; mso-hansi-font-family: Calibri; mso-bidi-font-family: Calibri;'\u003eETCs scheduled for closure will be decommissioned only when\r\nand where the epidemiological situation and the strength of referral pathways\r\nthrough non-EVD facilities allow. Several ETCs will be unstaffed but remain on\r\na stand-by level of readiness, whereby stocks of protective equipment and\r\nessential medicines will be kept on-site such that the facility can become\r\noperational within 48 hours. This transition would be triggered by higher\r\noccupancy rates in nearby ETCs. Strategically located core ETCs will remain\r\nfully operational at their current capacity (Maintain) or a slightly reduced\r\ncapacity (Scale Down and Maintain).\u003c/span\u003e\u003c/i\u003e\u003c/p\u003e\u003c/div\u003e",
+  "extent": {
+    "coordinates": [
+      [-13.6832, 4.3934],
+      [-7.6925, 10.374]
+    ]
+  },
+  "id": "267b6c8cdee749bf90bb2737d9e07fc8_0",
+  "item_name": "Ebola Treatment Centers",
+  "type": "ItemLayer",
+  "item_type": "Feature Layer",
+  "license": "\u003cspan style='color: rgb(0, 0, 0); line-height: normal; font-family: monospace; font-size: medium; white-space: pre-wrap; background-color: rgb(255, 255, 255);'\u003eData are based on situation reports provided by countries. The boundaries and names shown and the designations used on this site do not imply the expression of any opinion whatsoever on the part of the World Health Organization concerning the legal status of any country, territory, city or area or of its authorities, or concerning the delimitation of its frontiers or boundaries. Dotted and dashed lines on maps represent approximate border lines for which there may not yet be full agreement.\u003c/span\u003e",
+  "main_group_description": "Open Data hosting site",
+  "main_group_thumbnail_url": "https://www.arcgis.com/sharing/rest/community/groups/bdccbf91281c4144914e765b1fe0c692/info/EbolaResponseHomeOpenData.png",
+  "main_group_title": "Open Data Sharing",
+  "name": "Ebola Treatment Centers",
+  "owner": "er_admin",
+  "tags": ["Open Data", "ETC", "Ebola Treatment Center", "Ebola", "WHO"],
+  "thumbnail_url": "https://www.arcgis.com/sharing/rest/content/items/267b6c8cdee749bf90bb2737d9e07fc8/info/thumbnail/outputimageETCLYR.png",
+  "sites": [{
+    "title": "Ebola Response",
+    "url": "http://home.ebolaresponse.opendata.arcgis.com",
+    "logo": "http://ebolaresponse.opendata.arcgis.com/favicon.ico"
+  }],
+  "public": null,
+  "created_at": "2015-04-07T10:08:55.000+00:00",
+  "updated_at": "2015-06-04T15:59:16.000+00:00",
+  "url": "http://maps.who.int/arcgis/rest/services/OpenData/CurrentItems/MapServer/0",
+  "views": null,
+  "quality": 85,
+  "coverage": "regional",
+  "current_version": 10.31,
+  "use_standardized_queries": true
+}

--- a/spec/fixtures/json_docs.rb
+++ b/spec/fixtures/json_docs.rb
@@ -12,4 +12,10 @@ module JsonDocs
   def full_geoblacklight
     File.read(File.join(File.dirname(__FILE__), './docs/full_geoblacklight.json'))
   end
+
+  ##
+  # A sample Esri OpenData metadata record
+  def esri_opendata_metadata
+    File.read(File.join(File.dirname(__FILE__), './docs/esri_open_data.json'))
+  end
 end

--- a/spec/lib/geo_combine/esri_open_data_spec.rb
+++ b/spec/lib/geo_combine/esri_open_data_spec.rb
@@ -1,0 +1,96 @@
+require 'spec_helper'
+
+RSpec.describe GeoCombine::EsriOpenData do
+  include JsonDocs
+  let(:esri_sample) { GeoCombine::EsriOpenData.new(esri_opendata_metadata) }
+  let(:metadata) { esri_sample.instance_variable_get(:@metadata) }
+  describe '#initialize' do
+    it 'parses metadata argument JSON to Hash' do
+      expect(esri_sample.instance_variable_get(:@metadata)).to be_an Hash
+    end
+    it 'puts extend data into @geometry' do
+      expect(esri_sample.instance_variable_get(:@geometry)).to be_an Array
+    end
+  end
+  describe '#to_geoblacklight' do
+    it 'calls geoblacklight_terms to create a GeoBlacklight object' do
+      expect(esri_sample).to receive(:geoblacklight_terms).and_return({})
+      expect(esri_sample.to_geoblacklight).to be_an GeoCombine::Geoblacklight
+    end
+  end
+  describe '#geoblacklight_terms' do
+    describe 'builds a hash which maps metadata' do
+      let(:metadata) { esri_sample.instance_variable_get(:@metadata) }
+      it 'with uuid' do
+        expect(esri_sample.geoblacklight_terms).to include(uuid: metadata['id'])
+      end
+      it 'with dc_identifier_s' do
+        expect(esri_sample.geoblacklight_terms).to include(dc_identifier_s: metadata['id'])
+      end
+      it 'with dc_title_s' do
+        expect(esri_sample.geoblacklight_terms).to include(dc_title_s: metadata['name'])
+      end
+      it 'with dc_description_s sanitized' do
+        expect(esri_sample).to receive(:sanitize_and_remove_lines).and_return 'sanitized'
+        expect(esri_sample.geoblacklight_terms).to include(dc_description_s: 'sanitized')
+      end
+      it 'with dc_rights_s' do
+        expect(esri_sample.geoblacklight_terms).to include(dc_rights_s: 'Public')
+      end
+      it 'with dct_provenance_s' do
+        expect(esri_sample.geoblacklight_terms).to include(dct_provenance_s: metadata['owner'])
+      end
+      it 'with dct_references_s' do
+        expect(esri_sample).to receive(:references).and_return ''
+        expect(esri_sample.geoblacklight_terms).to include(:dct_references_s)
+      end
+      it 'with georss_box_s' do
+        expect(esri_sample).to receive(:georss_box).and_return ''
+        expect(esri_sample.geoblacklight_terms).to include(georss_box_s: '')
+      end
+      it 'with layer_id_s that is blank' do
+        expect(esri_sample.geoblacklight_terms).to include(layer_id_s: '')
+      end
+      it 'with layer_geom_type_s' do
+        expect(esri_sample.geoblacklight_terms).to include(layer_geom_type_s: metadata['geometry_type'])
+      end
+      it 'with layer_modified_dt' do
+        expect(esri_sample.geoblacklight_terms).to include(layer_modified_dt: metadata['updated_at'])
+      end
+      it 'with layer_slug_s' do
+        expect(esri_sample.geoblacklight_terms).to include(layer_slug_s: metadata['id'])
+      end
+      it 'with solr_geom' do
+        expect(esri_sample).to receive(:envelope).and_return ''
+        expect(esri_sample.geoblacklight_terms).to include(solr_geom: '')
+      end
+      it 'with dc_subject_sm' do
+        expect(esri_sample.geoblacklight_terms).to include(dc_subject_sm: metadata['tags'])
+      end
+    end
+  end
+  describe '#references' do
+    it 'converts references to a JSON string' do
+      expect(esri_sample).to receive(:references_hash).and_return({})
+      expect(esri_sample.references).to be_an String
+    end
+  end
+  describe '#references_hash' do
+    it 'builds out references' do
+      expect(esri_sample.references_hash).to include('http://schema.org/url' => metadata['arcgis_online_item_url'])
+      expect(esri_sample.references_hash).to include('http://resources.arcgis.com/en/help/arcgis-rest-api' => metadata['url'])
+    end
+  end
+  describe '#georss_box' do
+    it 'creates a GeoRSS box' do
+      expect(esri_sample.georss_box).to be_an String
+      expect(esri_sample.georss_box.split(' ').count).to eq 4
+    end
+  end
+  describe '#envelope' do
+    it 'creates an envelope for use in Solr' do
+      expect(esri_sample.envelope).to be_an String
+      expect(esri_sample.envelope).to match /ENVELOPE\(/
+    end
+  end
+end

--- a/spec/lib/geo_combine/formatting_spec.rb
+++ b/spec/lib/geo_combine/formatting_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+RSpec.describe GeoCombine::Formatting do
+  let(:dirty) { "<p>paragraph</p> \n on a new line" }
+  subject { Object.new.extend(GeoCombine::Formatting) }
+  describe '#sanitize' do
+    it 'sanitizes a fragment' do
+      expect(subject.sanitize(dirty)).to_not match('<p>')
+    end
+  end
+  describe '#remove_lines' do
+    it 'removes new lines' do
+      expect(subject.remove_lines(dirty)).to_not match(/\n/)
+    end
+  end
+  describe '#sanitize_and_remove_lines' do
+    it 'returns a corrected string' do
+      expect(subject.sanitize_and_remove_lines(dirty)).to_not match('<p>')
+      expect(subject.sanitize_and_remove_lines(dirty)).to_not match(/\n/)
+    end
+  end
+end

--- a/spec/lib/geo_combine/geoblacklight_spec.rb
+++ b/spec/lib/geo_combine/geoblacklight_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe GeoCombine::Geoblacklight do
     end
   end
   describe '#enhance_metadata' do
-    let(:enhanced_geobl) { GeoCombine::Geoblacklight.new(basic_geoblacklight, 'dct_references_s' => '', 'layer_geom_type_s' => 'Polygon') }
+    let(:enhanced_geobl) { GeoCombine::Geoblacklight.new(basic_geoblacklight, 'dct_references_s' => '', 'layer_geom_type_s' => 'esriGeometryPolygon') }
     before { enhanced_geobl.enhance_metadata }
     it 'calls enhancement methods to validate document' do
       expect { basic_geobl.valid? }.to raise_error JSON::Schema::ValidationError
@@ -40,6 +40,12 @@ RSpec.describe GeoCombine::Geoblacklight do
     end
     it 'enhances the dc_subject_sm field' do
       expect(enhanced_geobl.metadata['dc_subject_sm']).to include 'Boundaries', 'Inland Waters'
+    end
+    it 'formats the date properly as ISO8601' do
+      expect(enhanced_geobl.metadata['layer_modified_dt']).to match(/Z$/)
+    end
+    it 'formats the geometry type field' do
+      expect(enhanced_geobl.metadata['layer_geom_type_s']).to eq 'Polygon'
     end
   end
   describe '#valid?' do


### PR DESCRIPTION
…light

 - also adds mixin `Formatting` for sanitizing strings


Metadata can be found in http://opendata.arcgis.com/ and you can use the `.json` extension on urls to get json metadata back