### PR TITLE
use schema fragment to validate data

### DIFF
--- a/lib/geo_combine/geoblacklight.rb
+++ b/lib/geo_combine/geoblacklight.rb
@@ -43,9 +43,7 @@ module GeoCombine
     # @return [Boolean]
     def valid?
       @schema ||= JSON.parse(open('https://raw.githubusercontent.com/geoblacklight/geoblacklight/master/schema/geoblacklight-schema.json').read)
-      data = to_json
-      data = [data] unless data.is_a? Array
-      JSON::Validator.validate!(@schema, data, validate_schema: true)
+      JSON::Validator.validate!(@schema, to_json, fragment: '#/properties/layer')
     end
 
     private


### PR DESCRIPTION
This PR uses a schema fragment to validate the document, and we don't need to validate the schema itself too.