### PR TITLE
Moved closing dl tag

### DIFF
--- a/lib/xslt/iso2html.xsl
+++ b/lib/xslt/iso2html.xsl
@@ -531,6 +531,7 @@
                   </xsl:for-each>
                 </dl>
           </dd>
+        </dl>
         </div>
             
  <!-- Spatial Reference Info -->
@@ -1063,8 +1064,7 @@
                   </dd>  
                 </xsl:if>
               </dl>
-            </dd>  
-          </dl>
+            </dd>        
         </div>
      </xsl:template> 
 </xsl:stylesheet>


### PR DESCRIPTION
I couldn't get this file to validate in Oxygen until I moved a </dl> from line 1067 to line 534.  This version now works using XSLT transform in Oxygen.  I haven't tried it within a GeoCombine script.