### PR TITLE
add upgrade_to_v1 logic to convert pre_v1 to v1 schema

### DIFF
--- a/lib/geo_combine/geoblacklight.rb
+++ b/lib/geo_combine/geoblacklight.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/object/blank'
+require 'active_support/core_ext/hash/except'
 require 'open-uri'
 
 module GeoCombine
@@ -9,6 +11,16 @@ module GeoCombine
     attr_reader :metadata
 
     GEOBLACKLIGHT_VERSION = 'v1.1.0'
+    SCHEMA_JSON_URL = "https://raw.githubusercontent.com/geoblacklight/geoblacklight/#{GEOBLACKLIGHT_VERSION}/schema/geoblacklight-schema.json".freeze
+    DEPRECATED_KEYS_V1 = %w[
+      uuid
+      georss_polygon_s
+      georss_point_s
+      georss_box_s
+      dc_relation_sm
+      solr_issued_i
+      solr_bbox
+    ].freeze
 
     ##
     # Initializes a GeoBlacklight object
@@ -24,7 +36,9 @@ module GeoCombine
     # Calls metadata enhancement methods for each key, value pair in the
     # metadata hash
     def enhance_metadata
-      @metadata.each do |key, value|
+      upgrade_to_v1 if metadata['geoblacklight_version'].blank?
+
+      metadata.each do |key, value|
         translate_formats(key, value)
         enhance_subjects(key, value)
         format_proper_date(key, value)
@@ -36,15 +50,15 @@ module GeoCombine
     ##
     # Returns a string of JSON from a GeoBlacklight hash
     # @return (String)
-    def to_json(_options = {})
-      JSON.pretty_generate(@metadata)
+    def to_json(options = {})
+      metadata.to_json(options)
     end
 
     ##
     # Validates a GeoBlacklight-Schema json document
     # @return [Boolean]
     def valid?
-      @schema ||= JSON.parse(open("https://raw.githubusercontent.com/geoblacklight/geoblacklight/#{GEOBLACKLIGHT_VERSION}/schema/geoblacklight-schema.json").read)
+      @schema ||= JSON.parse(open(SCHEMA_JSON_URL).read)
       JSON::Validator.validate!(@schema, to_json, fragment: '#/properties/layer') &&
         dct_references_validate! &&
         spatial_validate!
@@ -54,7 +68,7 @@ module GeoCombine
     # Validate dct_references_s
     # @return [Boolean]
     def dct_references_validate!
-      return true unless metadata.key?('dct_references_s')
+      return true unless metadata.key?('dct_references_s') # TODO: shouldn't we require this field?
       begin
         ref = JSON.parse(metadata['dct_references_s'])
         raise GeoCombine::Exceptions::InvalidDCTReferences, 'dct_references must be parsed to a Hash' unless ref.is_a?(Hash)
@@ -74,43 +88,72 @@ module GeoCombine
     # Enhances the 'dc_format_s' field by translating a format type to a valid
     # GeoBlacklight-Schema format
     def translate_formats(key, value)
-      @metadata[key] = formats[value] if key == 'dc_format_s' && formats.include?(value)
+      return unless key == 'dc_format_s' && formats.include?(value)
+      metadata[key] = formats[value]
     end
 
     ##
     # Enhances the 'layer_geom_type_s' field by translating from known types
     def translate_geometry_type(key, value)
-      @metadata[key] = geometry_types[value] if key == 'layer_geom_type_s' && geometry_types.include?(value)
+      return unless key == 'layer_geom_type_s' && geometry_types.include?(value)
+      metadata[key] = geometry_types[value]
     end
 
     ##
     # Enhances the 'dc_subject_sm' field by translating subjects to ISO topic
     # categories
     def enhance_subjects(key, value)
-      @metadata[key] = value.map do |val|
+      return unless key == 'dc_subject_sm'
+      metadata[key] = value.map do |val|
         if subjects.include?(val)
           subjects[val]
         else
           val
         end
-      end if key == 'dc_subject_sm'
+      end
     end
 
     ##
     # Formats the 'layer_modified_dt' to a valid valid RFC3339 date/time string
     # and ISO8601 (for indexing into Solr)
     def format_proper_date(key, value)
-      @metadata[key] = Time.parse(value).utc.iso8601 if key == 'layer_modified_dt'
+      return unless key == 'layer_modified_dt'
+      metadata[key] = Time.parse(value).utc.iso8601
     end
 
     def fields_should_be_array(key, value)
-      @metadata[key] = [value] if should_be_array.include?(key) && !value.kind_of?(Array)
+      return unless should_be_array.include?(key) && !value.is_a?(Array)
+      metadata[key] = [value]
     end
 
     ##
     # GeoBlacklight-Schema fields that should be type Array
     def should_be_array
-      ['dc_creator_sm', 'dc_subject_sm', 'dct_spatial_sm', 'dct_temporal_sm', 'dct_isPartOf_sm']
+      %w[
+        dc_creator_sm
+        dc_subject_sm
+        dct_spatial_sm
+        dct_temporal_sm
+        dct_isPartOf_sm
+      ].freeze
+    end
+
+    ##
+    # Converts a pre-v1.0 schema into a compliant v1.0 schema
+    def upgrade_to_v1
+      metadata['geoblacklight_version'] = '1.0'
+
+      # ensure required fields
+      metadata['dc_identifier_s'] = metadata['uuid'] if metadata['dc_identifier_s'].blank?
+
+      # normalize to alphanum and - only
+      metadata['layer_slug_s'].gsub!(/[^[[:alnum:]]]+/, '-') if metadata['layer_slug_s'].present?
+
+      # remove deprecated fields
+      metadata.except!(*DEPRECATED_KEYS_V1)
+
+      # ensure we have a proper v1 record
+      valid?
     end
   end
 end

--- a/spec/fixtures/docs/geoblacklight_pre_v1.json
+++ b/spec/fixtures/docs/geoblacklight_pre_v1.json
@@ -1,0 +1,37 @@
+{
+  "uuid": "urn:columbia.edu:Columbia.ESRI_Arcatlas_snow_ln",
+  "dc_identifier_s": "urn:columbia.edu:Columbia.ESRI_Arcatlas_snow_ln",
+  "dc_title_s": "Worldwide Snow Cover (Polygon), 1996",
+  "dc_description_s": "Snow Cover (Polygon) is a polyline theme representing rates or snowcover worldwide.",
+  "dc_rights_s": "Restricted",
+  "dct_provenance_s": "Columbia",
+  "dct_references_s": "{\"http://schema.org/downloadUrl\":\"https://www1.columbia.edu/sec/acis/eds/dgate/studies/C1301/data/snow_poly.zip\",\"http://www.w3.org/1999/xhtml\":\"https://geoblacklight-prod.cul.columbia.edu/metadata/fgdc/html/ESRI_Arcatlas_snow_ln.html\",\"http://www.isotc211.org/schemas/2005/gmd/\":\"https://geoblacklight-prod.cul.columbia.edu/metadata/fgdc/current/ESRI_Arcatlas_snow_ln.xml\"}",
+  "georss_box_s": "-85.0 -180.0 85.0 180.0",
+  "layer_id_s": "sde:columbia.ESRI_Arcatlas_snow_ln",
+  "layer_geom_type_s": "Polygon",
+  "layer_modified_dt": "2009-06-16T00:00:00Z",
+  "layer_slug_s": "sde-columbia-esri_arcatlas_snow_ln",
+  "solr_geom": "ENVELOPE(-180.0, 180.0, 85.0, -85.0)",
+  "solr_year_i": 1996,
+  "dc_creator_sm": [
+    "Environmental Systems Research Institute (Redlands, Calif.)"
+  ],
+  "dc_format_s": "Shapefile",
+  "dc_language_s": "",
+  "dc_publisher_s": "ESRI",
+  "dc_subject_sm": [
+    "climatologyMeteorologyAtmosphere"
+  ],
+  "dc_type_s": "Dataset",
+  "dct_spatial_sm": [
+    "Earth"
+  ],
+  "dct_temporal_sm": [
+    "1996"
+  ],
+  "dct_issued_s": "",
+  "dct_isPartOf_sm": [
+    "ArcAtlas"
+  ],
+  "georss_polygon_s": "85.0 -180.0 85.0 180.0 -85.0 180.0 -85.0 -180.0 85.0 -180.0"
+}

--- a/spec/fixtures/json_docs.rb
+++ b/spec/fixtures/json_docs.rb
@@ -34,4 +34,8 @@ module JsonDocs
   def ogp_tufts_vector
     File.read(File.join(File.dirname(__FILE__), './docs/ogp_tufts_vector.json'))
   end
+
+  def geoblacklight_pre_v1
+    File.read(File.join(File.dirname(__FILE__), './docs/geoblacklight_pre_v1.json'))
+  end
 end


### PR DESCRIPTION
@mejackreed This PR will upgrade to a v1 schema if `.enhance_metadata` is called. It also makes some changes for rubocop complaints.