### PR TITLE
Updating the version to release 0.4.0

### DIFF
--- a/lib/geo_combine/version.rb
+++ b/lib/geo_combine/version.rb
@@ -1,3 +1,3 @@
 module GeoCombine
-  VERSION = '0.3.1'
+  VERSION = '0.4.0'
 end


### PR DESCRIPTION
Do https://github.com/OpenGeoMetadata/GeoCombine/pull/87 and other improvements from the last release (https://github.com/OpenGeoMetadata/GeoCombine/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Aclosed+merged%3A%3E2017-08-01+) include any breaking changes?  From what I could assess they appear to be backwards-compatible.

Resolves #88