### PR TITLE
GBL Harvester: default document_transformer should delete solr_bboxtype fields

### DIFF
--- a/lib/geo_combine/geo_blacklight_harvester.rb
+++ b/lib/geo_combine/geo_blacklight_harvester.rb
@@ -34,6 +34,10 @@ module GeoCombine
           document.delete('_version_')
           document.delete('score')
           document.delete('timestamp')
+          document.delete('solr_bboxtype__minX')
+          document.delete('solr_bboxtype__minY')
+          document.delete('solr_bboxtype__maxX')
+          document.delete('solr_bboxtype__maxY')
           document
         end
       end

--- a/spec/lib/geo_combine/geo_blacklight_harvester_spec.rb
+++ b/spec/lib/geo_combine/geo_blacklight_harvester_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe GeoCombine::GeoBlacklightHarvester do
     describe 'document tranformations' do
       let(:docs) do
         [
-         { layer_slug_s: 'abc-123', _version_: '1', timestamp: '1999-12-31', score: 0.1 },
+         { layer_slug_s: 'abc-123', _version_: '1', timestamp: '1999-12-31', score: 0.1, solr_bboxtype__minX: -87.324704, solr_bboxtype__minY: 40.233691, solr_bboxtype__maxX: -87.174404, solr_bboxtype__maxY: 40.310695 },
          { layer_slug_s: 'abc-321', dc_source_s: 'abc-123' }
         ]
       end
@@ -68,7 +68,7 @@ RSpec.describe GeoCombine::GeoBlacklightHarvester do
           expect(stub_solr_connection).to receive(:update).with(
             hash_including(
               data: [
-                { layer_slug_s: 'abc-123', timestamp: '1999-12-31', score: 0.1 },
+                { layer_slug_s: 'abc-123', timestamp: '1999-12-31', score: 0.1, solr_bboxtype__minX: -87.324704, solr_bboxtype__minY: 40.233691, solr_bboxtype__maxX: -87.174404, solr_bboxtype__maxY: 40.310695 },
                 { layer_slug_s: 'abc-321', dc_source_s: 'abc-123' }
               ].to_json
             )
@@ -79,7 +79,7 @@ RSpec.describe GeoCombine::GeoBlacklightHarvester do
       end
 
       context 'when no transformer is set' do
-        it 'removes the _version_, timestamp, and score fields' do
+        it 'removes the _version_, timestamp, score, and solr_bboxtype__* fields' do
           expect(stub_solr_connection).to receive(:update).with(
             hash_including(
               data: [


### PR DESCRIPTION
Fixes #100

Since GeoBlacklight v2.0.0, and the introduction of our bbox overlap ratio feature, Solr will automatically generate fields and values for these four coordinates:

* solr_bboxtype__minX
* solr_bboxtype__minY
* solr_bboxtype__maxX
* solr_bboxtype__maxY

These fields need to be removed before harvested documents can be sent to Solr for indexing. 