### PR TITLE
Ingest non geoblacklight.json files

### DIFF
--- a/lib/tasks/geo_combine.rake
+++ b/lib/tasks/geo_combine.rake
@@ -41,12 +41,12 @@ namespace :geocombine do
     end
   end
 
-  desc 'Index all of the GeoBlacklight JSON documents'
+  desc 'Index all JSON documents except Layers.json'
   task :index do
     puts "Indexing #{ogm_path} into #{solr_url}"
     solr = RSolr.connect url: solr_url, adapter: :net_http_persistent
     Find.find(ogm_path) do |path|
-      next unless File.basename(path) == 'geoblacklight.json'
+      next unless File.basename(path).includes?('.json') && File.basename(path) != 'layers.json'
       doc = JSON.parse(File.read(path))
       [doc].flatten.each do |record|
         begin


### PR DESCRIPTION
This will now ingest any .json file except layers.json to support the 2 styles of metadata in opengeometadata

To test:

I set up my local and pulled Stanford's metadata and Harvard's metadata (Stanford uses the geoblacklight.json, Harvard doesn't). I indexed using this code, and it should index all the records for both repos, and skip the layers.json in Stanford's.