### PR TITLE
Fix solr indexing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,4 +6,3 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'byebug'
-gem 'faraday-net_http_persistent', '~> 2.0'

--- a/Gemfile
+++ b/Gemfile
@@ -6,4 +6,4 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'byebug'
-gem 'faraday', ENV['FARADAY_VERSION'] if ENV['FARADAY_VERSION'].to_s != ''
+gem 'faraday-net_http_persistent', '~> 2.0'

--- a/geo_combine.gemspec
+++ b/geo_combine.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'json-schema'
   spec.add_dependency 'sanitize'
   spec.add_dependency 'thor'
+  spec.add_dependency 'faraday-net_http_persistent', '~> 2.0'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'

--- a/geo_combine.gemspec
+++ b/geo_combine.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'activesupport'
   spec.add_dependency 'rsolr'
-  spec.add_dependency 'net-http-persistent', '~> 2.0' # pin since faraday (rsolr) doesn't work correctly with 3.x
   spec.add_dependency 'nokogiri'
   spec.add_dependency 'json-schema'
   spec.add_dependency 'sanitize'

--- a/lib/tasks/geo_combine.rake
+++ b/lib/tasks/geo_combine.rake
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-require 'net/http'
 require 'json'
 require 'rsolr'
 require 'find'
 require 'geo_combine/geo_blacklight_harvester'
+require 'faraday/net_http_persistent'
 
 namespace :geocombine do
   desc 'Clone OpenGeoMetadata repositories'

--- a/spec/lib/geo_combine/geo_blacklight_harvester_spec.rb
+++ b/spec/lib/geo_combine/geo_blacklight_harvester_spec.rb
@@ -159,9 +159,9 @@ RSpec.describe GeoCombine::GeoBlacklightHarvester do
 
     let(:first_results_response) do
       { 'data' => [
-        { 'links' => { 'self' => 'https://example.com/catalog/abc-123' } },
-        { 'links' => { 'self' => 'https://example.com/catalog/abc-321' } }
-      ],
+          { 'links' => { 'self' => 'https://example.com/catalog/abc-123' } },
+          { 'links' => { 'self' => 'https://example.com/catalog/abc-321' } }
+        ],
         'links' => { 'next' => 'https://example.com/catalog.json?f%5Bdct_provenance_s%5D%5B%5D=INSTITUTION&per_page=100&page=2' } }
     end
 

--- a/spec/lib/tasks/geo_combine_spec.rb
+++ b/spec/lib/tasks/geo_combine_spec.rb
@@ -33,7 +33,7 @@ describe 'geo_combine.rake' do
 
   describe 'geocombine:index' do
     it 'only indexes .json files but not layers.json' do
-      rsolr_mock = instance_double('RSolr::Client')
+      rsolr_mock = instance_double(RSolr::Client)
       allow(rsolr_mock).to receive(:update)
       allow(rsolr_mock).to receive(:commit)
       allow(RSolr).to receive(:connect).and_return(rsolr_mock)


### PR DESCRIPTION
I was having errors when I was trying to use the solr indexing, based on the errors it looks like the gem version lock was no longer working and we have to switch to the new faraday net http persistent, so that's what I tried to do here