### PR TITLE
Ensure CI is locked to ruby v3.0

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [2.7, 3.0, 3.1]
+        ruby: [2.7, '3.0', 3.1]
         faraday_version: [''] # Defaults to whatever's the most recent version.
         include:
           - ruby: 2.7


### PR DESCRIPTION
When testing on ruby 3.0, we need to specify the version as a string,
otherwise YAML will interpret 3.0 as the integer 3. This causes the
actual requirement to become ~3, which allows for downloading e.g.
Ruby v3.2 when we wanted v3.0.

See for example:
https://github.com/OpenGeoMetadata/GeoCombine/actions/runs/3897283862/jobs/6654792458#step:3:11
