### PR TITLE
Support querying the configured solr url when indexing

### DIFF
--- a/lib/geo_combine/indexer.rb
+++ b/lib/geo_combine/indexer.rb
@@ -16,6 +16,10 @@ module GeoCombine
       @solr = solr
     end
 
+    def solr_url
+      @solr.options[:url]
+    end
+
     # Index everything and return the number of docs successfully indexed
     def index(docs, commit_within: ENV.fetch('SOLR_COMMIT_WITHIN', 5000).to_i)
       indexed_count = 0

--- a/lib/tasks/geo_combine.rake
+++ b/lib/tasks/geo_combine.rake
@@ -27,7 +27,7 @@ namespace :geocombine do
   task :index do
     harvester = GeoCombine::Harvester.new
     indexer = GeoCombine::Indexer.new
-    puts "Indexing #{harvester.ogm_path} into #{indexer.solr.url}"
+    puts "Indexing #{harvester.ogm_path} into #{indexer.solr_url}"
     total = indexer.index(harvester.docs_to_index)
     puts "Indexed #{total} documents"
   end


### PR DESCRIPTION
This fixes an issue where we try to print the active solr URL
when geocombine:index is invoked, but the Indexer doesn't know it,
causing Rake to report that the number of arguments is wrong.
