### PR TITLE
Harvesting reporting / tests

### DIFF
--- a/lib/geo_combine/harvester.rb
+++ b/lib/geo_combine/harvester.rb
@@ -89,8 +89,9 @@ module GeoCombine
     # List of repository names to harvest
     def repositories
       @repositories ||= JSON.parse(Net::HTTP.get(self.class.ogm_api_uri))
-                            .map { |repo| repo['name'] if (repo['size']).positive? }
-                            .reject { |repo| self.class.denylist.include? repo }
+                            .filter { |repo| repo['size'].positive? }
+                            .map { |repo| repo['name'] }
+                            .reject { |name| self.class.denylist.include? name }
     end
   end
 end

--- a/lib/geo_combine/harvester.rb
+++ b/lib/geo_combine/harvester.rb
@@ -59,7 +59,9 @@ module GeoCombine
       repo_path = File.join(@ogm_path, repo)
       clone(repo) unless File.directory? repo_path
 
-      Git.open(repo_path).pull && 1
+      Git.open(repo_path).pull
+      puts "Updated #{repo}"
+      1
     end
 
     # Update all repositories
@@ -72,10 +74,15 @@ module GeoCombine
     # If the repository already exists, skip it.
     def clone(repo)
       repo_path = File.join(@ogm_path, repo)
-      return 0 if File.directory? repo_path
+      if File.directory? repo_path
+        puts "Skipping clone to #{repo_path}; directory exists"
+        return 0
+      end
 
       repo_url = "https://github.com/OpenGeoMetadata/#{repo}.git"
-      Git.clone(repo_url, nil, path: ogm_path, depth: 1) && 1
+      Git.clone(repo_url, nil, path: ogm_path, depth: 1)
+      puts "Cloned #{repo_url}"
+      1
     end
 
     # Clone all repositories via git

--- a/spec/lib/geo_combine/harvester_spec.rb
+++ b/spec/lib/geo_combine/harvester_spec.rb
@@ -15,7 +15,8 @@ RSpec.describe GeoCombine::Harvester do
     [
       { name: repo_name, size: 100 },
       { name: 'another-institution', size: 100 },
-      { name: 'aardvark', size: 300 } # on denylist
+      { name: 'aardvark', size: 300 }, # on denylist
+      { name: 'empty', size: 0 }       # no data
     ].to_json
   end
 


### PR DESCRIPTION
- Ensure correct handling of OGM repos with no data
- Improve console output for harvest tasks

output looked a little confusing when harvesting/indexing multiple repos at a time (e.g. you'd see "Cloned 0 repositories" because things were skipped if you already had the repo locally). this cleans up the output and makes sure we handle the empty repositories in the OGM namespace.