### PR TITLE
Use the automatic bundling and caching of the setup-ruby action

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -7,12 +7,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Ruby
+    - name: Set up Ruby and install dependencies
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.7
-    - name: Install dependencies
-      run: bundle install
+        bundler-cache: true
     - name: Run linter
       run: bundle exec rubocop
 
@@ -28,16 +27,11 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Set up Ruby
+    - name: Set up Ruby and install dependencies
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
-
-    - name: Install bundler
-      run: gem install bundler -v 2.1.1
-
-    - name: Install dependencies
-      run: bundle _2.1.1_ install
+        bundler-cache: true
       env:
         FARADAY_VERSION: ${{ matrix.faraday_version }}
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,6 +11,7 @@ AllCops:
   Exclude:
   - 'geo_combine.gemspec'
   - 'tmp/**/*'
+  - 'vendor/bundle/**/*'
 
 RSpec/DescribeClass:
   Enabled: false


### PR DESCRIPTION
This switches CI to use the automatic `bundle install` and caching
functionality provided by the setup-ruby action:
https://github.com/ruby/setup-ruby#caching-bundle-install-automatically

Also ensures we get latest bundler — not sure why we were installing a particular version in CI.
