### PR TITLE
Add: a per_page param to OGM API URI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@
 mkmf.log
 .tool-versions
 .byebug_history
+.ruby-version

--- a/lib/geo_combine/harvester.rb
+++ b/lib/geo_combine/harvester.rb
@@ -24,7 +24,7 @@ module GeoCombine
 
     # GitHub API endpoint for OpenGeoMetadata repositories
     def self.ogm_api_uri
-      URI('https://api.github.com/orgs/opengeometadata/repos')
+      URI('https://api.github.com/orgs/opengeometadata/repos?per_page=1000')
     end
 
     def initialize(

--- a/spec/lib/geo_combine/harvester_spec.rb
+++ b/spec/lib/geo_combine/harvester_spec.rb
@@ -107,4 +107,10 @@ RSpec.describe GeoCombine::Harvester do
       expect(harvester.clone_all).to eq(2)
     end
   end
+
+  describe '#ogm_api_uri' do
+    it 'includes a per_page param' do
+      expect(described_class.send('ogm_api_uri').to_s).to include('per_page')
+    end
+  end
 end


### PR DESCRIPTION
HT @karenmajewicz

This PR allows GeoCombine to harvest all repositories by passing a `per_page` param along with the API call.

### Before
```
ewlarson@beanburrito .internal_test_app % bundle exec rake geocombine:clone --trace
** Invoke geocombine:clone (first_time)
** Execute geocombine:clone
Cloned https://github.com/OpenGeoMetadata/shared-repository.git
Cloned https://github.com/OpenGeoMetadata/edu.stanford.purl.git
Cloned https://github.com/OpenGeoMetadata/edu.princeton.arks.git
Cloned https://github.com/OpenGeoMetadata/edu.virginia.git
Cloned https://github.com/OpenGeoMetadata/edu.nyu.git
Cloned https://github.com/OpenGeoMetadata/edu.harvard.git
Cloned https://github.com/OpenGeoMetadata/edu.umn.git
Cloned https://github.com/OpenGeoMetadata/edu.tufts.git
Cloned https://github.com/OpenGeoMetadata/edu.columbia.git
Cloned https://github.com/OpenGeoMetadata/edu.lclark.git
Cloned https://github.com/OpenGeoMetadata/gov.data.git
Cloned https://github.com/OpenGeoMetadata/geobtaa.git
Cloned https://github.com/OpenGeoMetadata/edu.uarizona.git
Cloned https://github.com/OpenGeoMetadata/edu.berkeley.git
Cloned https://github.com/OpenGeoMetadata/edu.cornell.git
Cloned https://github.com/OpenGeoMetadata/edu.vt.git
Cloned https://github.com/OpenGeoMetadata/edu.upenn.git
Cloned https://github.com/OpenGeoMetadata/edu.mit.git
Cloned https://github.com/OpenGeoMetadata/ca.frdr.geodisy.git
Cloned https://github.com/OpenGeoMetadata/edu.wisc.git
Cloned 20 repositories
```

### After
```
ewlarson@beanburrito GeoCombine % bundle exec rake geocombine:clone
Cloned https://github.com/OpenGeoMetadata/shared-repository.git
Cloned https://github.com/OpenGeoMetadata/edu.stanford.purl.git
Cloned https://github.com/OpenGeoMetadata/edu.princeton.arks.git
Cloned https://github.com/OpenGeoMetadata/edu.virginia.git
Cloned https://github.com/OpenGeoMetadata/edu.nyu.git
Cloned https://github.com/OpenGeoMetadata/edu.harvard.git
Cloned https://github.com/OpenGeoMetadata/edu.umn.git
Cloned https://github.com/OpenGeoMetadata/edu.tufts.git
Cloned https://github.com/OpenGeoMetadata/edu.columbia.git
Cloned https://github.com/OpenGeoMetadata/edu.lclark.git
Cloned https://github.com/OpenGeoMetadata/gov.data.git
Cloned https://github.com/OpenGeoMetadata/geobtaa.git
Cloned https://github.com/OpenGeoMetadata/edu.uarizona.git
Cloned https://github.com/OpenGeoMetadata/edu.berkeley.git
Cloned https://github.com/OpenGeoMetadata/edu.cornell.git
Cloned https://github.com/OpenGeoMetadata/edu.vt.git
Cloned https://github.com/OpenGeoMetadata/edu.upenn.git
Cloned https://github.com/OpenGeoMetadata/edu.mit.git
Cloned https://github.com/OpenGeoMetadata/ca.frdr.geodisy.git
Cloned https://github.com/OpenGeoMetadata/edu.wisc.git
Cloned https://github.com/OpenGeoMetadata/edu.uchicago.git
Cloned https://github.com/OpenGeoMetadata/edu.indiana.git
Cloned https://github.com/OpenGeoMetadata/edu.illinois.git
Cloned https://github.com/OpenGeoMetadata/edu.umich.git
Cloned https://github.com/OpenGeoMetadata/edu.psu.git
Cloned https://github.com/OpenGeoMetadata/edu.msu.git
Cloned https://github.com/OpenGeoMetadata/edu.uiowa.git
Cloned https://github.com/OpenGeoMetadata/edu.umd.git
Cloned https://github.com/OpenGeoMetadata/edu.gmu.git
Cloned https://github.com/OpenGeoMetadata/edu.purdue.git
Cloned https://github.com/OpenGeoMetadata/edu.unl.git
Cloned https://github.com/OpenGeoMetadata/edu.osu.git
Cloned https://github.com/OpenGeoMetadata/edu.rutgers.git
Cloned 33 repositories
```

Fixes #149