### PR TITLE
Bug: Explicit require net/http

### DIFF
--- a/lib/geo_combine/harvester.rb
+++ b/lib/geo_combine/harvester.rb
@@ -3,6 +3,7 @@
 require 'json'
 require 'find'
 require 'git'
+require 'net/http'
 
 module GeoCombine
   # Harvests Geoblacklight documents from OpenGeoMetadata for indexing

--- a/lib/geo_combine/ogp.rb
+++ b/lib/geo_combine/ogp.rb
@@ -75,7 +75,7 @@ module GeoCombine
         dc_publisher_s: metadata['Publisher'],
         dc_subject_sm: subjects,
         dc_type_s: 'Dataset'
-      }.delete_if { |_k, v| v.nil? }
+      }.compact
     end
 
     def date


### PR DESCRIPTION
Hi folks! 

We're working on a small CLI gem for our in-house GBL that uses GeoCombine. We hit a small bug with `GeoCombine::Harvester`. calling `.repositories` throws:

```sh 
NameError:
       uninitialized constant GeoCombine::Harvester::Net
```

from this line https://github.com/OpenGeoMetadata/GeoCombine/blob/2d59072b8e0221b258f78353f8299a625e8889c5/lib/geo_combine/harvester.rb#L104

Adding an explicit `require 'net/http'` to `harvester.rb` solved it; this PR includes that & a small second commit to make rubocop test pass (edit: looks redundant with #157?)

Spec tests passed locally on ruby-3.2.2.