### PR TITLE
GBL --> Aardvark Migrator Refactors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ mkmf.log
 .tool-versions
 .byebug_history
 .ruby-version
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,3 @@ mkmf.log
 .tool-versions
 .byebug_history
 .ruby-version
-.idea/

--- a/lib/geo_combine/migrators/v1_aardvark_migrator.rb
+++ b/lib/geo_combine/migrators/v1_aardvark_migrator.rb
@@ -51,16 +51,16 @@ module GeoCombine
       def convert_non_crosswalked_fields
         # Keys may or may not include whitespace, so we normalize them.
         # Resource class is required so we default to "Other"; resource type is not required.
-        @v2_hash['gbl_resourceClass_s'] = RESOURCE_CLASS_MAP[@v1_hash['dc_type_s'].gsub(/\s+/, '')] || ['Other']
-        resource_type = RESOURCE_TYPE_MAP[@v1_hash['layer_geom_type_s'].gsub(/\s+/, '')]
+        @v2_hash['gbl_resourceClass_s'] = RESOURCE_CLASS_MAP[@v1_hash['dc_type_s']&.gsub(/\s+/, '')] || ['Other']
+        resource_type = RESOURCE_TYPE_MAP[@v1_hash['layer_geom_type_s']&.gsub(/\s+/, '')]
         @v2_hash['gbl_resourceType_s'] = resource_type unless resource_type.nil?
 
         # If the user specified a collection id map, use it to convert the collection names to ids
         is_part_of = @v1_hash['dct_isPartOf_sm']&.map { |name| @collection_id_map[name] }&.compact
-        if is_part_of.empty?
-          @v2_hash.delete('dct_isPartOf_sm')
-        else
+        if is_part_of.present?
           @v2_hash['dct_isPartOf_sm'] = is_part_of
+        else
+          @v2_hash.delete('dct_isPartOf_sm')
         end
       end
 


### PR DESCRIPTION
## Problem
`v1_aardvark_migrator` was failing when `RESOURCE_CLASS_MAP[@v1_hash['dc_type_s']` and `RESOURCE_TYPE_MAP[@v1_hash['layer_geom_type_s']` returned `nil` when `gsub` was called (`lib/geo_combine/migrators/v1_aardvark_migrator.rb:54` and `lib/geo_combine/migrators/v1_aardvark_migrator.rb:55`)

## Solution
- add save-nav method (`&`) to `gsub`
- make guard clause for `is_part_of` explicit (will handle `nil`)