### PR TITLE
Make OGM tasks more production-ready

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -10,7 +10,7 @@ jobs:
     - name: Set up Ruby and install dependencies
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.7
+        ruby-version: 3.1
         bundler-cache: true
     - name: Run linter
       run: bundle exec rubocop
@@ -19,11 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [2.7, '3.0', 3.1]
-        faraday_version: [''] # Defaults to whatever's the most recent version.
-        include:
-          - ruby: 2.7
-            faraday_version: '~> 1.0'
+        ruby: [3.1, 3.2, 3.3]
+        faraday_version: ['', '~> 1.0'] # Defaults to whatever's the most recent version.
     steps:
     - uses: actions/checkout@v2
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,7 +5,7 @@ require:
 inherit_from: .rubocop_todo.yml
 
 AllCops:
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.1
   DisplayCopNames: true
   NewCops: enable
   Exclude:
@@ -14,6 +14,9 @@ AllCops:
   - 'vendor/bundle/**/*'
 
 RSpec/DescribeClass:
+  Enabled: false
+
+RSpec/MultipleMemoizedHelpers:
   Enabled: false
 
 RSpec/BeforeAfterAll:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 A Ruby toolkit for managing geospatial metadata, including:
 
-- tasks for cloning, updating, and indexing OpenGeoMetdata metadata
+- tasks for cloning, updating, and indexing OpenGeoMetadata metadata
 - library for converting metadata between standards
 
 ## Installation
@@ -19,11 +19,15 @@ gem 'geo_combine'
 
 And then execute:
 
-    $ bundle install
+```sh
+$ bundle install
+```
 
 Or install it yourself as:
 
-    $ gem install geo_combine
+```sh
+$ gem install geo_combine
+```
 
 ## Usage
 
@@ -70,6 +74,14 @@ GeoCombine::Migrators::V1AardvarkMigrator.new(v1_hash: record, collection_id_map
 ```
 
 ### OpenGeoMetadata
+
+#### Logging
+
+Some of the tools and scripts in this gem use Ruby's `Logger` class to print information to `$stderr`. By default, the log level is set to `Logger::INFO`. For more verbose information, you can set the `LOG_LEVEL` environment variable to `DEBUG`:
+
+```sh
+$ LOG_LEVEL=DEBUG bundle exec rake geocombine:clone
+```
 
 #### Clone OpenGeoMetadata repositories locally
 
@@ -124,21 +136,12 @@ To index into Solr, GeoCombine requires a Solr instance that is running the
 $ bundle exec rake geocombine:index
 ```
 
-Indexes the `geoblacklight.json` files in cloned repositories to a Solr index running at http://127.0.0.1:8983/solr
+If Blacklight is installed in the ruby environment and a solr index is configured, the rake task will use the solr index configured in the Blacklight application (this is the case when invoking GeoCombine from your GeoBlacklight installation). If Blacklight is unavailable, the rake task will try to find a Solr instance running at `http://localhost:8983/solr/blacklight-core`.
 
-##### Custom Solr location
-
-Solr location can also be specified by an environment variable `SOLR_URL`.
+You can also set a the Solr instance URL using `SOLR_URL`:
 
 ```sh
 $ SOLR_URL=http://www.example.com:1234/solr/collection bundle exec rake geocombine:index
-```
-
-Depending on your Solr instance's performance characteristics, you may want to
-change the [`commitWithin` parameter](https://lucene.apache.org/solr/guide/6_6/updatehandlers-in-solrconfig.html) (in milliseconds):
-
-```sh
-$ SOLR_COMMIT_WITHIN=100 bundle exec rake geocombine:index
 ```
 
 ### Harvesting and indexing documents from GeoBlacklight sites
@@ -185,10 +188,6 @@ Crawl delays can be configured (in seconds) either globally for all sites or on 
 ##### Solr's commitWithin (default: 5000 milliseconds)
 
 Solr's commitWithin option can be configured (in milliseconds) by passing a value under the commit_within key.
-
-##### Debugging (default: false)
-
-The harvester and indexer will only `puts` content when errors happen. It is possible to see some progress information by setting the debug configuration option.
 
 #### Transforming Documents
 

--- a/geo_combine.gemspec
+++ b/geo_combine.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'thor'
   spec.add_dependency 'faraday-net_http_persistent', '~> 2.0'
   spec.add_dependency 'git'
+  spec.add_dependency 'faraday-retry', '~> 2.2'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'

--- a/lib/geo_combine/ckan_metadata.rb
+++ b/lib/geo_combine/ckan_metadata.rb
@@ -65,7 +65,7 @@ module GeoCombine
     def envelope_from_spatial(delimiter)
       bbox = GeoCombine::BoundingBox.from_string_delimiter(
         extras('spatial'),
-        delimiter: delimiter
+        delimiter:
       )
       begin
         bbox.to_envelope if bbox.valid?

--- a/lib/geo_combine/geoblacklight.rb
+++ b/lib/geo_combine/geoblacklight.rb
@@ -13,7 +13,7 @@ module GeoCombine
     attr_reader :metadata
 
     GEOBLACKLIGHT_VERSION = '1.0'
-    SCHEMA_JSON_URL = "https://raw.githubusercontent.com/OpenGeoMetadata/opengeometadata.github.io/main/docs/schema/geoblacklight-schema-#{GEOBLACKLIGHT_VERSION}.json"
+    SCHEMA_JSON_URL = "https://raw.githubusercontent.com/OpenGeoMetadata/opengeometadata.github.io/main/docs/schema/geoblacklight-schema-#{GEOBLACKLIGHT_VERSION}.json".freeze
     DEPRECATED_KEYS_V1 = %w[
       uuid
       georss_polygon_s

--- a/lib/geo_combine/indexer.rb
+++ b/lib/geo_combine/indexer.rb
@@ -1,47 +1,126 @@
 # frozen_string_literal: true
 
 require 'rsolr'
+require 'faraday/retry'
 require 'faraday/net_http_persistent'
+require 'geo_combine/logger'
 
 module GeoCombine
   # Indexes Geoblacklight documents into Solr
   class Indexer
     attr_reader :solr
 
-    def self.solr(url: ENV.fetch('SOLR_URL', 'http://127.0.0.1:8983/solr/blacklight-core'))
-      RSolr.connect url: url, adapter: :net_http_persistent
+    def initialize(solr: nil, logger: GeoCombine::Logger.logger)
+      @logger = logger
+      @batch_size = ENV.fetch('SOLR_BATCH_SIZE', 100).to_i
+
+      # If SOLR_URL is set, use it; if in a Geoblacklight app, use its solr core
+      solr_url = ENV.fetch('SOLR_URL', nil)
+      solr_url ||= Blacklight.default_index.connection.base_uri.to_s if defined? Blacklight
+
+      # If neither, warn and try to use local Blacklight default solr core
+      if solr_url.nil?
+        @logger.warn 'SOLR_URL not set; using Blacklight default'
+        solr_url = 'http://localhost:8983/solr/blacklight-core'
+      end
+
+      @solr = solr || RSolr.connect(client, url: solr_url)
     end
 
-    def initialize(solr: GeoCombine::Indexer.solr)
-      @solr = solr
+    # Index everything and return the number of docs successfully indexed
+    def index(docs)
+      # Track total indexed and time spent
+      @logger.info "indexing into #{solr_url}"
+      total_indexed = 0
+      start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+      # Index in batches; set batch size via BATCH_SIZE
+      batch = []
+      docs.each do |doc, path|
+        if batch.size < @batch_size
+          batch << [doc, path]
+        else
+          total_indexed += index_batch(batch)
+          batch = []
+        end
+      end
+      total_indexed += index_batch(batch) unless batch.empty?
+
+      # Issue a commit to make sure all documents are indexed
+      @solr.commit
+      end_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      sec = end_time - start_time
+      @logger.info format('indexed %<total_indexed>d documents in %<sec>.2f seconds', total_indexed:, sec:)
+      total_indexed
     end
 
+    # URL to the solr instance being used
     def solr_url
       @solr.options[:url]
     end
 
-    # Index everything and return the number of docs successfully indexed
-    def index(docs, commit_within: ENV.fetch('SOLR_COMMIT_WITHIN', 5000).to_i)
-      indexed_count = 0
+    private
 
-      docs.each do |record, path|
-        # log the unique identifier for the record for debugging
-        id = record['id'] || record['dc_identifier_s']
-        puts "Indexing #{id}: #{path}" if $DEBUG
+    # Index a batch of documents; if we fail, index them all individually
+    def index_batch(batch)
+      docs = batch.map(&:first)
+      @solr.update(data: batch_json(docs), params:, headers:)
+      @logger.debug "indexed batch (#{batch.size} docs)"
+      batch.size
+    rescue RSolr::Error::Http => e
+      @logger.error "error indexing batch (#{batch.size} docs): #{format_error(e)}"
+      @logger.warn 'retrying documents individually'
+      batch.map { |doc, path| index_single(doc, path) }.compact.size
+    end
 
-        # index the record into solr
-        @solr.update params: { commitWithin: commit_within, overwrite: true },
-                     data: [record].to_json,
-                     headers: { 'Content-Type' => 'application/json' }
+    # Index a single document; if it fails, log the error and continue
+    def index_single(doc, path)
+      @solr.add(doc, params:, headers:)
+      @logger.debug "indexed #{path}"
+      doc
+    rescue RSolr::Error::Http => e
+      @logger.error "error indexing #{path}: #{format_error(e)}"
+      nil
+    end
 
-        # count the number of records successfully indexed
-        indexed_count += 1
-      rescue RSolr::Error::Http => e
-        puts e
+    # Generate a JSON string to send to solr update API for a batch of documents
+    def batch_json(batch)
+      batch.map { |doc| "add: { doc: #{doc.to_json} }" }.join(",\n").prepend('{ ').concat(' }')
+    end
+
+    # Generate a friendly error message for logging including status code and message
+    def format_error(error)
+      code = error.response[:status]
+      status_info = "#{code} #{RSolr::Error::Http::STATUS_CODES[code.to_i]}"
+      error_info = parse_solr_error(error)
+      [status_info, error_info].compact.join(' - ')
+    end
+
+    # Extract the specific error message from a solr JSON error response, if any
+    def parse_solr_error(error)
+      JSON.parse(error.response[:body]).dig('error', 'msg')
+    rescue StandardError
+      nil
+    end
+
+    def headers
+      { 'Content-Type' => 'application/json' }
+    end
+
+    def params
+      { overwrite: true }
+    end
+
+    def client
+      @client ||= Faraday.new do |conn|
+        conn.request :retry, max: 3, interval: 1, backoff_factor: 2, exceptions: [
+          Faraday::TimeoutError,
+          Faraday::ConnectionFailed,
+          Faraday::TooManyRequestsError
+        ]
+        conn.response :raise_error
+        conn.adapter :net_http_persistent
       end
-
-      @solr.commit
-      indexed_count
     end
   end
 end

--- a/lib/geo_combine/logger.rb
+++ b/lib/geo_combine/logger.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'logger'
+
+module GeoCombine
+  # Logger for gem
+  class Logger
+    def self.logger
+      @logger ||= ::Logger.new(
+        $stderr,
+        progname: 'GeoCombine',
+        level: ENV.fetch('LOG_LEVEL', 'info').to_sym
+      )
+    end
+  end
+end

--- a/lib/tasks/geo_combine.rake
+++ b/lib/tasks/geo_combine.rake
@@ -12,24 +12,20 @@ namespace :geocombine do
   desc 'Clone OpenGeoMetadata repositories'
   task :clone, [:repo] do |_t, args|
     harvester = GeoCombine::Harvester.new
-    total = args[:repo] ? harvester.clone(args.repo) : harvester.clone_all
-    puts "Cloned #{total} repositories"
+    args[:repo] ? harvester.clone(args.repo) : harvester.clone_all
   end
 
   desc '"git pull" OpenGeoMetadata repositories'
   task :pull, [:repo] do |_t, args|
     harvester = GeoCombine::Harvester.new
-    total = args[:repo] ? harvester.pull(args.repo) : harvester.pull_all
-    puts "Updated #{total} repositories"
+    args[:repo] ? harvester.pull(args.repo) : harvester.pull_all
   end
 
   desc 'Index all JSON documents except Layers.json'
   task :index do
     harvester = GeoCombine::Harvester.new
     indexer = GeoCombine::Indexer.new
-    puts "Indexing #{harvester.ogm_path} into #{indexer.solr_url}"
-    total = indexer.index(harvester.docs_to_index)
-    puts "Indexed #{total} documents"
+    indexer.index(harvester.docs_to_index)
   end
 
   namespace :geoblacklight_harvester do

--- a/spec/lib/geo_combine/geo_blacklight_harvester_spec.rb
+++ b/spec/lib/geo_combine/geo_blacklight_harvester_spec.rb
@@ -5,8 +5,9 @@ require 'spec_helper'
 require 'rsolr'
 
 RSpec.describe GeoCombine::GeoBlacklightHarvester do
-  subject(:harvester) { described_class.new(site_key) }
+  subject(:harvester) { described_class.new(site_key, logger:) }
 
+  let(:logger) { instance_double(Logger, warn: nil, info: nil, error: nil, debug: nil) }
   let(:site_key) { :INSTITUTION }
   let(:stub_json_response) { '{}' }
   let(:stub_solr_connection) { double('RSolr::Connection') }
@@ -40,7 +41,7 @@ RSpec.describe GeoCombine::GeoBlacklightHarvester do
 
     let(:docs) { [{ layer_slug_s: 'abc-123' }, { layer_slug_s: 'abc-321' }] }
     let(:stub_json_response) do
-      { response: { docs: docs, pages: { current_page: 1, total_pages: 1 } } }.to_json
+      { response: { docs:, pages: { current_page: 1, total_pages: 1 } } }.to_json
     end
 
     it 'adds documents returned to solr' do
@@ -142,7 +143,7 @@ RSpec.describe GeoCombine::GeoBlacklightHarvester do
         ).and_return(stub_second_response.to_json)
         base_url = 'https://example.com?f%5Bdct_provenance_s%5D%5B%5D=INSTITUTION&format=json&per_page=100'
         docs = described_class::LegacyBlacklightResponse.new(response: stub_first_response,
-                                                             base_url: base_url).documents
+                                                             base_url:).documents
 
         expect(docs.to_a).to eq([first_docs, second_docs])
       end
@@ -182,7 +183,7 @@ RSpec.describe GeoCombine::GeoBlacklightHarvester do
 
         base_url = 'https://example.com?f%5Bdct_provenance_s%5D%5B%5D=INSTITUTION&format=json&per_page=100'
         docs = described_class::ModernBlacklightResponse.new(response: first_results_response,
-                                                             base_url: base_url).documents
+                                                             base_url:).documents
 
         expect(docs.to_a).to eq([
                                   [{ 'layer_slug_s' => 'abc-123' }, { 'layer_slug_s' => 'abc-321' }],

--- a/spec/lib/geo_combine/indexer_spec.rb
+++ b/spec/lib/geo_combine/indexer_spec.rb
@@ -3,10 +3,22 @@
 require 'geo_combine/indexer'
 require 'spec_helper'
 
-RSpec.describe GeoCombine::Indexer do
-  subject(:indexer) { described_class.new(solr: solr) }
+# Mock an available Blacklight installation
+class FakeBlacklight
+  def self.default_index
+    Repository
+  end
 
-  let(:solr) { instance_double(RSolr::Client) }
+  class Repository
+    def self.connection; end
+  end
+end
+
+RSpec.describe GeoCombine::Indexer do
+  subject(:indexer) { described_class.new(solr:, logger:) }
+
+  let(:logger) { instance_double(Logger, warn: nil, info: nil, error: nil, debug: nil) }
+  let(:solr) { instance_double(RSolr::Client, options: { url: 'TEST' }) }
   let(:docs) do
     [
       [{ 'id' => '1' }, 'path/to/record1.json'],              # v1.0 schema
@@ -21,34 +33,67 @@ RSpec.describe GeoCombine::Indexer do
 
   describe '#initialize' do
     before do
-      stub_const('ENV', 'SOLR_URL' => 'http://localhost:8983/solr/geoblacklight')
       allow(RSolr).to receive(:connect).and_return(solr)
     end
 
-    it 'connects to a solr instance if set in the environment' do
-      described_class.new
-      expect(RSolr).to have_received(:connect).with(
-        url: 'http://localhost:8983/solr/geoblacklight',
-        adapter: :net_http_persistent
-      )
+    context 'when solr url is set in the environment' do
+      before do
+        stub_const('ENV', 'SOLR_URL' => 'http://localhost:8983/solr/geoblacklight')
+      end
+
+      it 'connects to the solr instance' do
+        described_class.new(logger:)
+        expect(RSolr).to have_received(:connect).with(
+          be_a(Faraday::Connection),
+          url: 'http://localhost:8983/solr/geoblacklight'
+        )
+      end
+    end
+
+    context 'when there is a configured Blacklight connection' do
+      before do
+        stub_const('Blacklight', FakeBlacklight)
+        allow(FakeBlacklight::Repository).to receive(:connection).and_return(
+          instance_double(RSolr::Client, base_uri: URI('http://localhost:8983/solr/geoblacklight'))
+        )
+      end
+
+      it 'connects to the solr instance' do
+        described_class.new(logger:)
+        expect(RSolr).to have_received(:connect).with(
+          be_a(Faraday::Connection),
+          url: 'http://localhost:8983/solr/geoblacklight'
+        )
+      end
+    end
+
+    context 'when solr url is not set' do
+      before do
+        stub_const('ENV', {})
+      end
+
+      it 'falls back to the Blacklight default' do
+        described_class.new(logger:)
+        expect(RSolr).to have_received(:connect).with(
+          be_a(Faraday::Connection),
+          url: 'http://localhost:8983/solr/blacklight-core'
+        )
+      end
     end
   end
 
   describe '#index' do
-    it 'posts each record to solr as JSON' do
-      indexer.index([docs[0]], commit_within: 1)
-      expect(solr).to have_received(:update).with(
-        params: { commitWithin: 1, overwrite: true },
-        data: [docs[0][0]].to_json,
-        headers: { 'Content-Type' => 'application/json' }
-      )
-    end
+    let(:solr_error_msg) {  { error: { msg: 'error message' } }.to_json }
+    let(:solr_response) { { status: '400', body: solr_error_msg } }
+    let(:error) { RSolr::Error::Http.new({ uri: URI('') }, solr_response) }
 
-    it 'prints the id and path of each record in debug mode' do
-      $DEBUG = true
-      expect { indexer.index([docs[0]]) }.to output("Indexing 1: path/to/record1.json\n").to_stdout
-      expect { indexer.index([docs[1]]) }.to output("Indexing 2: path/to/record2.json\n").to_stdout
-      $DEBUG = false
+    it 'sends records in batches to solr' do
+      indexer.index(docs)
+      expect(solr).to have_received(:update).with(
+        data: "{ add: { doc: {\"id\":\"1\"} },\nadd: { doc: {\"dc_identifier_s\":\"2\"} } }",
+        headers: { 'Content-Type' => 'application/json' },
+        params: { overwrite: true }
+      )
     end
 
     it 'commits changes to solr after indexing' do
@@ -58,6 +103,32 @@ RSpec.describe GeoCombine::Indexer do
 
     it 'returns the count of records successfully indexed' do
       expect(indexer.index(docs)).to eq 2
+    end
+
+    context 'when an error occurs during batch indexing' do
+      before do
+        allow(solr).to receive(:update).and_raise(error)
+        allow(solr).to receive(:add)
+      end
+
+      it 'attempts to index records individually' do
+        total = indexer.index(docs)
+        expect(solr).to have_received(:add).twice
+        expect(total).to eq 2
+      end
+    end
+
+    context 'when an error occurs during individual indexing' do
+      before do
+        allow(solr).to receive(:update).and_raise(error)
+        allow(solr).to receive(:add).with(docs[0][0], anything).and_raise(error)
+        allow(solr).to receive(:add).with(docs[1][0], anything)
+      end
+
+      it 'continues indexing' do
+        total = indexer.index(docs)
+        expect(total).to eq 1
+      end
     end
   end
 end

--- a/spec/lib/geo_combine/migrators/v1_aardvark_migrator_spec.rb
+++ b/spec/lib/geo_combine/migrators/v1_aardvark_migrator_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe GeoCombine::Migrators::V1AardvarkMigrator do
       it 'converts the collection names to ids' do
         input_hash = JSON.parse(full_geoblacklight)
         collection_id_map = { 'Uganda GIS Maps and Data, 2000-2010' => 'stanford-rb371kw9607' }
-        output = described_class.new(v1_hash: input_hash, collection_id_map: collection_id_map).run
+        output = described_class.new(v1_hash: input_hash, collection_id_map:).run
         expect(output['dct_isPartOf_sm']).to eq(['stanford-rb371kw9607'])
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,7 +22,7 @@ require 'webmock/rspec'
 WebMock.allow_net_connect!
 
 # include the spec support files
-Dir['./spec/support/**/*.rb'].sort.each { |f| require f }
+Dir['./spec/support/**/*.rb'].each { |f| require f }
 
 RSpec.configure do |config|
   config.include Helpers


### PR DESCRIPTION
This admittedly large PR happened because I wanted to set up regularly scheduled updates from OpenGeoMetadata for Earthworks via `cron`, and GeoCombine seemed like the best way to do it (https://github.com/sul-dlss/earthworks/issues/639).

It tackles several outstanding issues:
- Removes support for EOL and near-EOL ruby versions 2.7 and 3.0, rubocops things to match 3.1
- Uses a batch indexing strategy for the OGM indexer, which allows for indexing almost all the records in OGM in under 10 minutes (on my laptop, at least)
- Adds logging capabilities to the indexers and harvester (#138)
- Makes indexing report and continue gracefully instead of failing when solr reports that the metadata is bad (#168)
- Makes indexing try again if the connection to solr drops
- If we're indexing and `Blacklight` is available to import (i.e. in a GeoBlacklight installation), automatically target the solr core configured for it (#166)