### PR TITLE
Ensure that locn_geometry is populated when migrating v1 to Aardvark

### DIFF
--- a/spec/fixtures/docs/full_geoblacklight_aardvark.json
+++ b/spec/fixtures/docs/full_geoblacklight_aardvark.json
@@ -44,6 +44,7 @@
     "stanford-rb371kw9607"
   ],
   "dcat_bbox":"ENVELOPE(29.572742, 35.000308, 4.234077, -1.478794)",
+  "locn_geometry":"ENVELOPE(29.572742, 35.000308, 4.234077, -1.478794)",
   "gbl_indexYear_im":[
     2005
   ],


### PR DESCRIPTION
Previously we were setting dcat_bbox but not locn_geometry based
on the v1 solr_geom. The latter is also crucial, because we can't
do spatial search or render previews without it.

This ensures that we always populate locn_geometry if we had solr_geom,
and then also fill in dcat_bbox if the geometry happens to be in the
ENVELOPE() format.
