### PR TITLE
Batch Indexing Fix

### DIFF
--- a/lib/geo_combine/indexer.rb
+++ b/lib/geo_combine/indexer.rb
@@ -41,7 +41,7 @@ module GeoCombine
           batch << [doc, path]
         else
           total_indexed += index_batch(batch)
-          batch = []
+          batch = [[doc, path]]
         end
       end
       total_indexed += index_batch(batch) unless batch.empty?

--- a/lib/geo_combine/indexer.rb
+++ b/lib/geo_combine/indexer.rb
@@ -35,16 +35,10 @@ module GeoCombine
       start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
 
       # Index in batches; set batch size via BATCH_SIZE
-      batch = []
-      docs.each do |doc, path|
-        if batch.size < @batch_size
-          batch << [doc, path]
-        else
-          total_indexed += index_batch(batch)
-          batch = [[doc, path]]
-        end
+      docs.each_slice(@batch_size) do |slice|
+        batch = slice.map { |doc, path| [doc, path] }
+        total_indexed += index_batch(batch)
       end
-      total_indexed += index_batch(batch) unless batch.empty?
 
       # Issue a commit to make sure all documents are indexed
       @solr.commit

--- a/spec/lib/geo_combine/indexer_spec.rb
+++ b/spec/lib/geo_combine/indexer_spec.rb
@@ -96,6 +96,18 @@ RSpec.describe GeoCombine::Indexer do
       )
     end
 
+    context 'when the number of docs is greater than batch size' do
+      before do
+        stub_const('ENV', 'SOLR_BATCH_SIZE' => 10)
+      end
+
+      let(:docs) { (1..40).map { |n| [{ 'id' => n }, "path/to/record#{n}.json"] } }
+
+      it 'indexes the correct number of documents' do
+        expect(indexer.index(docs)).to eq 40
+      end
+    end
+
     it 'commits changes to solr after indexing' do
       indexer.index(docs)
       expect(solr).to have_received(:commit).once


### PR DESCRIPTION
## Problem

During indexing, when the number of documents is greater than the batch size, a document is skipped each iteration.

## Solution

- Add spec that exercises the situation.
- Use `.each_slice` for a cleaner way to slice up document list into batches.

Addresses #172