### PR TITLE
Clean up naming and usage of validation predicates

### DIFF
--- a/lib/geo_combine/bounding_box.rb
+++ b/lib/geo_combine/bounding_box.rb
@@ -48,8 +48,6 @@ module GeoCombine
     end
 
     def self.from_envelope(envelope)
-      return if envelope.nil?
-
       envelope = envelope[/.*ENVELOPE\(([^)]*)/, 1].split(',')
       new(
         west: envelope[0],
@@ -63,8 +61,6 @@ module GeoCombine
     # @param [String] spatial w,s,e,n or w s e n
     # @param [String] delimiter "," or " "
     def self.from_string_delimiter(spatial, delimiter: ',')
-      return if spatial.nil?
-
       spatial = spatial.split(delimiter)
       new(
         west: spatial[0],

--- a/lib/geo_combine/esri_open_data.rb
+++ b/lib/geo_combine/esri_open_data.rb
@@ -4,6 +4,7 @@ module GeoCombine
   # Data model for ESRI's open data portal metadata
   class EsriOpenData
     include GeoCombine::Formatting
+
     attr_reader :metadata
 
     ##

--- a/lib/geo_combine/ogp.rb
+++ b/lib/geo_combine/ogp.rb
@@ -8,6 +8,7 @@ module GeoCombine
   class OGP
     class InvalidMetadata < RuntimeError; end
     include GeoCombine::Formatting
+
     attr_reader :metadata
 
     ##

--- a/spec/features/fgdc2html_spec.rb
+++ b/spec/features/fgdc2html_spec.rb
@@ -5,6 +5,7 @@ require 'spec_helper'
 # TODO: Provide additional expectations on html structure
 describe 'FGDC to html' do
   include XmlDocs
+
   let(:page) { GeoCombine::Fgdc.new(tufts_fgdc).to_html }
 
   describe 'Identification Information' do

--- a/spec/features/iso2html_spec.rb
+++ b/spec/features/iso2html_spec.rb
@@ -5,6 +5,7 @@ require 'spec_helper'
 # TODO: Provide additional expectations on html structure
 describe 'ISO 19139 to html' do
   include XmlDocs
+
   let(:page) { GeoCombine::Iso19139.new(stanford_iso).to_html }
 
   describe 'Identification Information' do

--- a/spec/lib/geo_combine/ckan_metadata_spec.rb
+++ b/spec/lib/geo_combine/ckan_metadata_spec.rb
@@ -4,6 +4,7 @@ require 'spec_helper'
 
 RSpec.describe GeoCombine::CkanMetadata do
   include JsonDocs
+
   let(:ckan_sample) { described_class.new(ckan_metadata) }
 
   describe '#to_geoblacklight' do

--- a/spec/lib/geo_combine/esri_open_data_spec.rb
+++ b/spec/lib/geo_combine/esri_open_data_spec.rb
@@ -4,6 +4,7 @@ require 'spec_helper'
 
 RSpec.describe GeoCombine::EsriOpenData do
   include JsonDocs
+
   let(:esri_sample) { described_class.new(esri_opendata_metadata) }
   let(:metadata) { esri_sample.instance_variable_get(:@metadata) }
 

--- a/spec/lib/geo_combine/fgdc_spec.rb
+++ b/spec/lib/geo_combine/fgdc_spec.rb
@@ -4,6 +4,7 @@ require 'spec_helper'
 
 RSpec.describe GeoCombine::Fgdc do
   include XmlDocs
+
   let(:fgdc_object) { described_class.new(tufts_fgdc) }
 
   describe '#initialize' do
@@ -32,7 +33,7 @@ RSpec.describe GeoCombine::Fgdc do
     end
 
     it 'is not valid due to bad modification date but valid otherwise' do
-      expect { fgdc_geobl.valid? }.to raise_error(JSON::Schema::ValidationError, /layer_modified_dt/)
+      expect { fgdc_geobl.validate! }.to raise_error(JSON::Schema::ValidationError, /layer_modified_dt/)
       fgdc_geobl.metadata.delete 'layer_modified_dt'
       expect(fgdc_geobl).to be_valid
     end

--- a/spec/lib/geo_combine/iso19139_spec.rb
+++ b/spec/lib/geo_combine/iso19139_spec.rb
@@ -4,6 +4,7 @@ require 'spec_helper'
 
 RSpec.describe GeoCombine::Iso19139 do
   include XmlDocs
+
   let(:iso_object) { described_class.new(stanford_iso) }
 
   describe '#initialize' do


### PR DESCRIPTION
This clarifies the difference between validate! methods that
should raise, and the valid? method that does not raise.

Placates Rubocop.
